### PR TITLE
Operations WIP

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,7 @@ api.add = (meta, options, callback) => {
       }, {
         collection: results.generateUuid.eventCollection,
         fields: {'meta.blockHeight': 1, 'meta.blockOrder': 1},
-        options: {sparse: true, unique: true, background: false}
+        options: {sparse: true, unique: false, background: false}
       }, {
         collection: results.generateUuid.eventCollection,
         fields: {'meta.deleted': 1, 'eventHash': 1},

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,7 +160,7 @@ api.add = (meta, options, callback) => {
         options: {unique: true, background: false}
       }, {
         collection: results.generateUuid.blockCollection,
-        fields: {'block.type': 1, 'meta.consensusDate': 1},
+        fields: {'block.type': 1, 'block.blockHeight': 1},
         options: {unique: false, background: false}
       }, {
         collection: results.generateUuid.blockCollection,

--- a/lib/index.js
+++ b/lib/index.js
@@ -152,8 +152,8 @@ api.add = (meta, options, callback) => {
         options: {sparse: true, unique: false, background: false}
       }, {
         collection: results.generateUuid.eventCollection,
-        fields: {'meta.deleted': 1, 'eventHash': 1},
-        options: {unique: false, background: false}
+        fields: {'meta.deleted': 1, eventHash: 1},
+        options: {unique: true, background: false}
       }, {
         collection: results.generateUuid.blockCollection,
         fields: {id: 1},

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,6 +142,10 @@ api.add = (meta, options, callback) => {
         fields: {'event.type': 1, 'meta.consensusDate': 1},
         options: {unique: false, background: false}
       }, {
+        collection: results.generateUuid.eventCollection,
+        fields: {'meta.blockHeight': 1},
+        options: {unique: false, background: false}
+      }, {
         collection: results.generateUuid.blockCollection,
         fields: {id: 1},
         options: {unique: true, background: false}

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,9 +12,11 @@ const brLedgerNode = require('bedrock-ledger-node');
 const database = require('bedrock-mongodb');
 const logger = require('./logger');
 const uuid = require('uuid/v4');
+// const util = require('util');
 const BedrockError = bedrock.util.BedrockError;
 const LedgerBlockStorage = require('./ledgerBlockStorage');
 const LedgerEventStorage = require('./ledgerEventStorage');
+const LedgerOperationStorage = require('./ledgerOperationStorage');
 const LedgerStateMachineStorage = require('./ledgerStateMachineStorage');
 
 require('./config');
@@ -83,6 +85,7 @@ api.add = (meta, options, callback) => {
         uuid: ledgerUuid,
         eventCollection: ledgerUuid + '-event',
         blockCollection: ledgerUuid + '-block',
+        operationCollection: ledgerUuid + '-operation',
         stateMachineCollection: ledgerUuid + '-state-machine'
       });
     },
@@ -92,11 +95,12 @@ api.add = (meta, options, callback) => {
       const record = {
         id: 'urn:uuid:' + results.generateUuid.uuid,
         ledger: {
+          blockCollection: results.generateUuid.blockCollection,
+          eventCollection: results.generateUuid.eventCollection,
           id: 'urn:uuid:' + results.generateUuid.uuid,
           ledger: options.ledgerId,
-          eventCollection: results.generateUuid.eventCollection,
-          blockCollection: results.generateUuid.blockCollection,
-          stateMachineCollection: results.generateUuid.stateMachineCollection
+          operationCollection: results.generateUuid.operationCollection,
+          stateMachineCollection: results.generateUuid.stateMachineCollection,
         },
         meta: _.defaults(meta, {
           created: now,
@@ -117,9 +121,10 @@ api.add = (meta, options, callback) => {
     openLedgerCollections: ['insert', (results, callback) => {
       // open the ledger collections
       const ledgerCollections = [
-        results.generateUuid.eventCollection,
         results.generateUuid.blockCollection,
-        results.generateUuid.stateMachineCollection
+        results.generateUuid.eventCollection,
+        results.generateUuid.operationCollection,
+        results.generateUuid.stateMachineCollection,
       ];
       database.openCollections(ledgerCollections, callback);
     }],
@@ -144,7 +149,7 @@ api.add = (meta, options, callback) => {
       }, {
         collection: results.generateUuid.eventCollection,
         fields: {'meta.blockHeight': 1, 'meta.blockOrder': 1},
-        options: {unique: false, background: false}
+        options: {sparse: true, unique: true, background: false}
       }, {
         collection: results.generateUuid.eventCollection,
         fields: {'meta.deleted': 1, 'eventHash': 1},
@@ -178,6 +183,10 @@ api.add = (meta, options, callback) => {
         fields: {'meta.consensusDate': 1},
         options: {unique: false, background: false}
       }, {
+        collection: results.generateUuid.operationCollection,
+        fields: {'meta.eventHash': 1, 'meta.eventOrder': 1},
+        options: {unique: true, background: false}
+      }, {
         collection: results.generateUuid.stateMachineCollection,
         fields: {id: 1},
         options: {unique: true, sparse: true, background: false}
@@ -185,13 +194,15 @@ api.add = (meta, options, callback) => {
     }],
     getLedgerStorage: ['createCollectionIndexes', (results, callback) => {
       const lsOptions = {
-        storageId: 'urn:uuid:' + results.generateUuid.uuid,
-        eventCollection:
-          database.collections[results.generateUuid.eventCollection],
         blockCollection:
           database.collections[results.generateUuid.blockCollection],
+        eventCollection:
+          database.collections[results.generateUuid.eventCollection],
+        operationCollection:
+          database.collections[results.generateUuid.operationCollection],
         stateMachineCollection:
-          database.collections[results.generateUuid.stateMachineCollection]
+          database.collections[results.generateUuid.stateMachineCollection],
+        storageId: 'urn:uuid:' + results.generateUuid.uuid,
       };
       const ledgerStorage = new LedgerStorage(lsOptions);
       callback(null, ledgerStorage);
@@ -233,8 +244,9 @@ api.get = (storageId, options, callback) => {
       }
       // open the ledger collections
       const ledgerCollections = [
-        record.ledger.eventCollection,
         record.ledger.blockCollection,
+        record.ledger.eventCollection,
+        record.ledger.operationCollection,
         record.ledger.stateMachineCollection
       ];
       database.openCollections(ledgerCollections, callback);
@@ -249,6 +261,8 @@ api.get = (storageId, options, callback) => {
         database.collections[results.find.ledger.blockCollection],
       eventCollection:
         database.collections[results.find.ledger.eventCollection],
+      operationCollection:
+        database.collections[results.find.ledger.operationCollection],
       stateMachineCollection:
         database.collections[results.find.ledger.stateMachineCollection]
     };
@@ -368,6 +382,8 @@ api.getLedgerIterator = function(options, callback) {
 class LedgerStorage {
   constructor(options) {
     this.id = options.storageId;
+    this.operations = new LedgerOperationStorage(options);
+    options.operationStorage = this.operations;
     this.events = new LedgerEventStorage(options);
     options.eventStorage = this.events;
     this.blocks = new LedgerBlockStorage(options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,11 @@ api.add = (meta, options, callback) => {
         options: {unique: false, background: false}
       }, {
         collection: results.generateUuid.eventCollection,
-        fields: {'meta.blockHeight': 1},
+        fields: {'meta.blockHeight': 1, 'meta.blockOrder': 1},
+        options: {unique: false, background: false}
+      }, {
+        collection: results.generateUuid.eventCollection,
+        fields: {'meta.deleted': 1, 'eventHash': 1},
         options: {unique: false, background: false}
       }, {
         collection: results.generateUuid.blockCollection,

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,10 @@ api.add = (meta, options, callback) => {
         collection: results.generateUuid.stateMachineCollection,
         fields: {id: 1},
         options: {unique: true, sparse: true, background: false}
+      }, {
+        collection: results.generateUuid.stateMachineCollection,
+        fields: {'meta.blockHeight': 1},
+        options: {unique: false, background: false}
       }], callback);
     }],
     getLedgerStorage: ['createCollectionIndexes', (results, callback) => {

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -17,11 +17,11 @@ const {BedrockError} = bedrock.util;
  * particular ledger.
  */
 module.exports = class LedgerBlockStorage {
-  constructor(options) {
+  constructor({blockCollection, eventCollection}) {
     // assign the collection used for block storage
-    this.collection = options.blockCollection;
+    this.collection = blockCollection;
     // assign the collection used for events storage
-    this.eventCollection = options.eventCollection;
+    this.eventCollection = eventCollection;
   }
 
   /**
@@ -99,17 +99,13 @@ module.exports = class LedgerBlockStorage {
    * Gets the block that has consensus given a blockId.
    *
    * @param blockId - the identifier of the block that has consensus.
-   * @param options - a set of options used when retrieving the block(s).
+   * @param [consensus] `false` to retrieve a summary for a non-consensus
+   *   block instead.
    * @param callback(err, block) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   block - the block with the given ID that has consensus.
    */
-  get(blockId, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  get({blockId, consensus = true}, callback) {
     async.auto({
       find: callback => {
         // find an existing block with consensus
@@ -122,7 +118,7 @@ module.exports = class LedgerBlockStorage {
             $exists: true
           }
         };
-        if(options.consensus === false) {
+        if(!consensus) {
           query['meta.consensus'].$exists = false;
         }
         this.collection.findOne(query, callback);
@@ -145,23 +141,21 @@ module.exports = class LedgerBlockStorage {
     });
   }
 
+  // FIXME: this API is not used anywhere if if it should be kept, it needs
+  // to be updated to get eventhashes etc.
+
   /**
    * Gets the block summary for consensus block given a blockId.
    *
    * @param blockId - the identifier of the block that has consensus.
-   * @param options - a set of options used when retrieving the block(s).
-   *          [consensus] `false` to retrieve a summary for a non-consensus
-   *            block instead.
-   *          [eventHash] `true` to get all event hashes from `event`.
+   * @param [consensus] `false` to retrieve a summary for a non-consensus
+   *   block instead.
+   * @param [eventHash] `true` to get all event hashes from `event`.
    * @param callback(err, block) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   block - the block summary for the given ID that has consensus.
    */
-  getSummary(blockId, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
+  getSummary({blockId, consensus = true, eventHash}, callback) {
     // find an existing block with consensus
     const query = {
       id: database.hash(blockId),
@@ -172,11 +166,11 @@ module.exports = class LedgerBlockStorage {
         $exists: true
       }
     };
-    if(options.consensus === false) {
+    if(consensus === false) {
       query['meta.consensus'].$exists = false;
     }
     const projection = {};
-    if(options.eventHash) {
+    if(eventHash) {
       projection['block.event'] = 0;
     }
     this.collection.findOne(query, projection, (err, result) => {
@@ -200,17 +194,11 @@ module.exports = class LedgerBlockStorage {
    * Gets a block that has consensus given a blockHeight.
    *
    * @param blockHeight - the height of the block that has consensus.
-   * @param options - a set of options used when retrieving the block(s).
    * @param callback(err, block) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   block - the block with the given block height that has consensus.
    */
-  getByHeight(blockHeight, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  getByHeight(blockHeight, callback) {
     async.auto({
       find: callback => {
         // find an existing block with consensus
@@ -245,19 +233,14 @@ module.exports = class LedgerBlockStorage {
    * Gets the block summary for consensus block given a blockHeight.
    *
    * @param blockHeight - the height of the block that has consensus.
-   * @param options - a set of options used when retrieving the block(s).
-   *          [consensus] `false` to retrieve a summary for a non-consensus
-   *            block instead.
-   *          [eventHash] `true` to get all event hashes from `event`.
+   * @param [consensus] `false` to retrieve a summary for a non-consensus
+   * @param [eventHash] `true` to get all event hashes from `event`.
    * @param callback(err, block) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   block - the block summary for the given ID that has consensus.
    */
-  getSummaryByHeight(blockHeight, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
+  getSummaryByHeight(
+    {blockHeight, consensus = true, eventHash = false}, callback) {
     // find an existing block with consensus
     const query = {
       'block.blockHeight': blockHeight,
@@ -268,11 +251,11 @@ module.exports = class LedgerBlockStorage {
         $exists: true
       }
     };
-    if(options.consensus === false) {
+    if(consensus === false) {
       query['meta.consensus'].$exists = false;
     }
     const projection = {};
-    if(!options.eventHash) {
+    if(!eventHash) {
       projection['block.event'] = 0;
     }
     this.collection.findOne(query, projection, (err, result) => {
@@ -297,17 +280,11 @@ module.exports = class LedgerBlockStorage {
    * achieved consensus.
    *
    * @param blockId - the identifier of the block(s) to fetch from the ledger.
-   * @param options - a set of options used when retrieving the block(s).
    * @param callback(err, iterator) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   iterator - an iterator for all of the returned blocks.
    */
-  getAll(blockId, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  getAll(blockId, callback) {
     async.auto({
       find: callback => {
         // find an existing block
@@ -367,18 +344,12 @@ module.exports = class LedgerBlockStorage {
   /**
    * Retrieves the genesis block from the ledger.
    *
-   * @param options - a set of options used when retrieving the genesis block.
    * @param callback(err, result) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   result - the result with the genesis block.
    *     genesisBlock - the genesis block and its meta.
    */
-  getGenesis(options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  getGenesis(callback) {
     // find the genesis block with consensus
     const query = {
       'block.previousBlock': {$exists: false},
@@ -413,17 +384,12 @@ module.exports = class LedgerBlockStorage {
   /**
    * Retrieves the latest block from the ledger.
    *
-   * @param options - a set of options used when retrieving the latest block.
    * @param callback(err, result) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   result - the block.
    *     eventBlock - the latest events block and meta.
    */
-  getLatest(options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
+  getLatest(callback) {
     async.auto({
       block: callback => {
         // find the latest config block with consensus
@@ -432,7 +398,7 @@ module.exports = class LedgerBlockStorage {
           'meta.deleted': {$exists: false},
           'meta.consensus': {$exists: true}
         };
-        const sort = {'meta.consensusDate': -1};
+        const sort = {'block.blockHeight': -1};
         this.collection.find(query).sort(sort).limit(1).toArray(callback);
       },
       expandEvents: ['block', (results, callback) => {
@@ -454,17 +420,12 @@ module.exports = class LedgerBlockStorage {
   /**
    * Retrieves a summary of the latest block from the ledger.
    *
-   * @param options - a set of options used when retrieving the latest block.
    * @param callback(err, result) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   result - the block.
    *     eventBlock - the latest events block summary.
    */
-  getLatestSummary(options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
+  getLatestSummary(callback) {
     // find the latest config block with consensus
     const query = {
       'block.type': 'WebLedgerEventBlock',
@@ -499,16 +460,10 @@ module.exports = class LedgerBlockStorage {
    *
    * @param blockHash - the hash of the block to update.
    * @param patch - the patch instructions to execute on the block.
-   * @param options - a set of options used when updating the block.
    * @param callback(err) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    */
-  update(blockHash, patch, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  update({blockHash, patch}, callback) {
     if(!Array.isArray(patch)) {
       throw new TypeError('patch must be an array');
     }
@@ -517,8 +472,6 @@ module.exports = class LedgerBlockStorage {
       buildUpdate: callback => {
         const setObject = {};
         const unsetObject = {};
-        const setFields = {};
-        const unsetFields = {};
         const pushFields = {};
         const pullFields = {};
 
@@ -609,16 +562,10 @@ module.exports = class LedgerBlockStorage {
    * Delete a block in the ledger given a block hash and a set of options.
    *
    * @param blockHash - the hash of the block to delete.
-   * @param options - a set of options used when deleting the block.
    * @param callback(err) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    */
-  remove(blockHash, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  remove(blockHash, callback) {
     async.auto({
       update: callback => {
         // find and delete the existing block

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -17,11 +17,13 @@ const {BedrockError} = bedrock.util;
  * particular ledger.
  */
 module.exports = class LedgerBlockStorage {
-  constructor({blockCollection, eventCollection}) {
+  constructor({blockCollection, eventCollection, eventStorage}) {
     // assign the collection used for block storage
     this.collection = blockCollection;
     // assign the collection used for events storage
     this.eventCollection = eventCollection;
+    // event storage API
+    this.eventStorage = eventStorage;
   }
 
   /**
@@ -598,8 +600,20 @@ module.exports = class LedgerBlockStorage {
   _expandEvents(block, callback) {
     block.event = [];
     const query = {'meta.blockHeight': block.blockHeight};
-    const projection = {_id: 0, event: 1};
-    this.eventCollection.find(query, projection).sort({'meta.blockOrder': 1})
-      .forEach(({event}) => block.event.push(event), callback);
+    const projection = {_id: 0, 'meta.eventHash': 1};
+    this.eventCollection.find(query, projection).toArray((err, eventHashes) => {
+      if(err) {
+        return callback(err);
+      }
+      eventHashes = eventHashes.map(r => r.meta.eventHash);
+      this.eventStorage.getMany({eventHashes}).sort({'meta.blockOrder': 1})
+        .toArray((err, events) => {
+          if(err) {
+            return callback(err);
+          }
+          block.event = events;
+          callback();
+      });
+    });
   }
 };

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -75,7 +75,7 @@ module.exports = class LedgerBlockStorage {
       },
       update: ['insert', (results, callback) => {
         async.timesLimit(event.length, 100, (i, callback) => {
-          const query = {eventHash: event[i]};
+          const query = {eventHash: database.hash(event[i])};
           this.eventCollection.update(
             query, {$set: {
               'meta.blockHeight': blockHeight,

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -10,7 +10,7 @@ const async = require('async');
 const bedrock = require('bedrock');
 const database = require('bedrock-mongodb');
 const logger = require('./logger');
-const BedrockError = bedrock.util.BedrockError;
+const {BedrockError} = bedrock.util;
 
 /**
  * The blocks API is used to perform operations on blocks associated with a
@@ -26,55 +26,58 @@ module.exports = class LedgerBlockStorage {
 
   /**
    * Adds a block in the ledger given a block, metadata associated with the
-   * block, and a set of options.
+   * block
    *
    * @param block - the block to create in the ledger.
    * @param meta - the metadata associated with the block.
    *   blockHash - the hash value of the block.
-   * @param options - a set of options used when creating the block.
    * @param callback(err) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   result - the result of the operation.
    *     block - the block that was committed to storage.
    *     meta - the metadata that was committed to storage.
    */
-  add(block, meta, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
+  add({block, meta}, callback) {
     if(!meta.blockHash) {
       return callback(new BedrockError(
         'A block hash for the given block was not specified.',
-        'BadRequest', {meta}));
+        'DataError', {meta}));
     }
-
+    const {blockHeight, event} = block;
+    // event does not get saved as part of the block
+    delete block.event;
     async.auto({
       insert: callback => {
         // insert the block
         const now = Date.now();
         const record = {
-          id: database.hash(block.id),
+          block,
           blockHash: database.hash(meta.blockHash),
-          block: block,
+          id: database.hash(block.id),
           meta: _.defaults(meta, {
             created: now,
             updated: now
-          })
+          }),
         };
 
-        logger.debug('adding block: ' + meta.blockHash);
+        logger.debug(`adding block: ${meta.blockHash}`);
 
         // FIXME: We should deconstruct the events from the blocks
 
-        this.collection.insert(
-          record, database.writeOptions, (err, result) => {
-            if(err) {
-              return callback(err);
-            }
-            callback(null, result.ops[0]);
-          });
-      }
+        this.collection.insert(record, database.writeOptions, (err, result) => {
+          if(err) {
+            return callback(err);
+          }
+          callback(null, result.ops[0]);
+        });
+      },
+      update: ['insert', (results, callback) => {
+
+        const query = {eventHash: {$in: event.map(h => database.hash(h))}};
+        this.eventCollection.update(
+          query, {$set: {'meta.blockHeight': blockHeight}},
+          database.writeOptions, callback);
+      }]
     }, (err, results) => {
       if(err) {
         if(database.isDuplicateError(err)) {
@@ -641,36 +644,10 @@ module.exports = class LedgerBlockStorage {
   }
 
   _expandEvents(block, callback) {
-    // find all events that must be fetched
-    const events = block.event || [];
-    const eventsToFetch = {};
-    for(let i = 0; i < events.length; ++i) {
-      const event = events[i];
-      // TODO: Determine if we want to expand other hash types
-      const isEventHash = typeof(event) === 'string' &&
-        event.startsWith('ni:///');
-      if(isEventHash) {
-        eventsToFetch[event] = i;
-      }
-    }
-    const hashes = Object.keys(eventsToFetch);
-    if(hashes.length === 0) {
-      // no event hashes to fetch
-      return callback();
-    }
-
-    // get all event hashes from event collection
-    const query = {
-      eventHash: {
-        $in: hashes
-      }
-    };
-    const projection = {
-      event: 1,
-      'meta.eventHash': 1,
-      _id: 0
-    };
+    block.event = [];
+    const query = {'meta.blockHeight': block.blockHeight};
+    const projection = {_id: 0, event: 1};
     this.eventCollection.find(query, projection).forEach(e =>
-      block.event[eventsToFetch[e.meta.eventHash]] = e.event, callback);
+      block.event.push(e.event), callback);
   }
 };

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -613,7 +613,7 @@ module.exports = class LedgerBlockStorage {
           }
           block.event = events.map(r => r.event);
           callback();
-      });
+        });
     });
   }
 };

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -611,7 +611,7 @@ module.exports = class LedgerBlockStorage {
           if(err) {
             return callback(err);
           }
-          block.event = events;
+          block.event = events.map(r => r.event);
           callback();
       });
     });

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -26,7 +26,7 @@ module.exports = class LedgerBlockStorage {
 
   /**
    * Adds a block in the ledger given a block, metadata associated with the
-   * block
+   * block.
    *
    * @param block - the block to create in the ledger.
    * @param meta - the metadata associated with the block.
@@ -61,9 +61,6 @@ module.exports = class LedgerBlockStorage {
         };
 
         logger.debug(`adding block: ${meta.blockHash}`);
-
-        // FIXME: We should deconstruct the events from the blocks
-
         this.collection.insert(record, database.writeOptions, (err, result) => {
           if(err) {
             return callback(err);
@@ -72,7 +69,6 @@ module.exports = class LedgerBlockStorage {
         });
       },
       update: ['insert', (results, callback) => {
-
         const query = {eventHash: {$in: event.map(h => database.hash(h))}};
         this.eventCollection.update(
           query, {$set: {'meta.blockHeight': blockHeight}},
@@ -87,7 +83,8 @@ module.exports = class LedgerBlockStorage {
         }
         return callback(err);
       }
-      callback(null, {block: results.insert.block, meta: results.insert.meta});
+      const {block, meta} = results.insert;
+      callback(null, {block, meta});
     });
   }
 

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -190,6 +190,7 @@ module.exports = class LedgerBlockStorage {
         if(!eventHash) {
           return callback();
         }
+        // TODO: make code DRY
         // FIXME: this might be accomplished with aggregate query
         // get event hashes
         const block = results.find.block;
@@ -296,6 +297,7 @@ module.exports = class LedgerBlockStorage {
         if(!eventHash) {
           return callback();
         }
+        // TODO: make code DRY
         // FIXME: this might be accomplished with aggregate query
         // get event hashes
         const block = results.find.block;
@@ -642,6 +644,7 @@ module.exports = class LedgerBlockStorage {
   // FIXME: this might be accomplished with aggregate query
   _expandEvents(block, callback) {
     block.event = [];
+    // TODO: make code DRY
     const query = {'meta.blockHeight': block.blockHeight};
     const projection = {_id: 0, 'meta.eventHash': 1};
     this.eventCollection.find(query, projection)

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -50,10 +50,7 @@ module.exports = class LedgerBlockStorage {
     }
     const {blockHeight, event} = block;
     // drop `event` from the block without mutating or cloning
-    const _block = _.pick(block, [
-      '@context', 'blockHeight', 'id', 'previousBlock', 'previousBlockHash',
-      'type'
-    ]);
+    const _block = _.pickBy(block, (v, k) => k !== 'event');
     async.auto({
       insert: callback => {
         // insert the block
@@ -77,10 +74,16 @@ module.exports = class LedgerBlockStorage {
         });
       },
       update: ['insert', (results, callback) => {
-        const query = {eventHash: {$in: event.map(h => database.hash(h))}};
-        this.eventCollection.update(
-          query, {$set: {'meta.blockHeight': blockHeight}},
-          database.writeOptions, callback);
+        // FIXME: some tests are sending in hashes as strings
+        async.timesLimit(event.length, 100, (i, callback) => {
+          const query = {eventHash: event[i]};
+          this.eventCollection.update(
+            query, {$set: {
+              'meta.blockHeight': blockHeight,
+              'meta.blockOrder': i
+            }},
+            database.writeOptions, callback);
+        }, callback);
       }]
     }, (err, results) => {
       if(err) {
@@ -597,7 +600,7 @@ module.exports = class LedgerBlockStorage {
     block.event = [];
     const query = {'meta.blockHeight': block.blockHeight};
     const projection = {_id: 0, event: 1};
-    this.eventCollection.find(query, projection).forEach(e =>
-      block.event.push(e.event), callback);
+    this.eventCollection.find(query, projection).sort({'meta.blockOrder': 1})
+      .forEach(({event}) => block.event.push(event), callback);
   }
 };

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -99,8 +99,7 @@ module.exports = class LedgerBlockStorage {
    * Gets the block that has consensus given a blockId.
    *
    * @param blockId - the identifier of the block that has consensus.
-   * @param [consensus] `false` to retrieve a summary for a non-consensus
-   *   block instead.
+   * @param [consensus] `false` to retrieve a non-consensus block instead.
    * @param callback(err, block) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   block - the block with the given ID that has consensus.

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -29,6 +29,8 @@ module.exports = class LedgerBlockStorage {
    * block.
    *
    * @param block - the block to create in the ledger.
+   *   blockHeight - the height of the block
+   *   event - an array of events associated with the block
    * @param meta - the metadata associated with the block.
    *   blockHash - the hash value of the block.
    * @param callback(err) - the callback to call when finished.
@@ -38,20 +40,26 @@ module.exports = class LedgerBlockStorage {
    *     meta - the metadata that was committed to storage.
    */
   add({block, meta}, callback) {
-    if(!meta.blockHash) {
-      return callback(new BedrockError(
-        'A block hash for the given block was not specified.',
-        'DataError', {meta}));
+    // check block
+    if(!(block && Number.isInteger(block.blockHeight) && block.event)) {
+      throw new TypeError(
+        '`block.blockHeight` and `block.event` are required.');
+    }
+    if(!(meta && meta.blockHash)) {
+      throw new TypeError('`meta.blockHash` is required.');
     }
     const {blockHeight, event} = block;
-    // event does not get saved as part of the block
-    delete block.event;
+    // drop `event` from the block without mutating or cloning
+    const _block = _.pick(block, [
+      '@context', 'blockHeight', 'id', 'previousBlock', 'previousBlockHash',
+      'type'
+    ]);
     async.auto({
       insert: callback => {
         // insert the block
         const now = Date.now();
         const record = {
-          block,
+          block: _block,
           blockHash: database.hash(meta.blockHash),
           id: database.hash(block.id),
           meta: _.defaults(meta, {
@@ -83,8 +91,7 @@ module.exports = class LedgerBlockStorage {
         }
         return callback(err);
       }
-      const {block, meta} = results.insert;
-      callback(null, {block, meta});
+      callback(null, {block: results.insert.block, meta: results.insert.meta});
     });
   }
 

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -159,37 +159,58 @@ module.exports = class LedgerBlockStorage {
    *   block - the block summary for the given ID that has consensus.
    */
   getSummary({blockId, consensus = true, eventHash}, callback) {
-    // find an existing block with consensus
-    const query = {
-      id: database.hash(blockId),
-      'meta.deleted': {
-        $exists: false
+    async.auto({
+      find: callback => {
+        const query = {
+          id: database.hash(blockId),
+          'meta.deleted': {
+            $exists: false
+          },
+          'meta.consensus': {
+            $exists: true
+          }
+        };
+        if(consensus === false) {
+          query['meta.consensus'].$exists = false;
+        }
+        const projection = {};
+        this.collection.findOne(query, projection, (err, record) => {
+          if(err) {
+            return callback(err);
+          }
+          if(!record) {
+            return callback(new BedrockError(
+              'A block with the given ID does not exist.',
+              'NotFoundError', {blockId}));
+          }
+          return callback(null, record);
+        });
       },
-      'meta.consensus': {
-        $exists: true
-      }
-    };
-    if(consensus === false) {
-      query['meta.consensus'].$exists = false;
-    }
-    const projection = {};
-    if(eventHash) {
-      projection['block.event'] = 0;
-    }
-    this.collection.findOne(query, projection, (err, result) => {
+      eventHashes: ['find', (results, callback) => {
+        if(!eventHash) {
+          return callback();
+        }
+        // FIXME: this might be accomplished with aggregate query
+        // get event hashes
+        const block = results.find.block;
+        const query = {'meta.blockHeight': block.blockHeight};
+        const projection = {_id: 0, 'meta.eventHash': 1};
+        this.eventCollection.find(query, projection)
+          .sort({'meta.blockOrder': 1})
+          .toArray((err, eventHashes) => {
+            if(err) {
+              return callback(err);
+            }
+            block.eventHash = eventHashes.map(r => r.meta.eventHash);
+            callback();
+          });
+      }]
+    }, (err, results) => {
       if(err) {
         return callback(err);
       }
-      if(!result) {
-        return callback(new BedrockError(
-          'A block with the given ID does not exist.',
-          'NotFoundError', {blockId}));
-      }
-      if(result.block.event) {
-        result.block.eventHash = result.block.event;
-        delete result.block.event;
-      }
-      callback(null, {block: result.block, meta: result.meta});
+      callback(
+        null, {block: results.find.block, meta: results.find.meta});
     });
   }
 
@@ -244,37 +265,58 @@ module.exports = class LedgerBlockStorage {
    */
   getSummaryByHeight(
     {blockHeight, consensus = true, eventHash = false}, callback) {
-    // find an existing block with consensus
-    const query = {
-      'block.blockHeight': blockHeight,
-      'meta.deleted': {
-        $exists: false
+    async.auto({
+      find: callback => {
+        const query = {
+          'block.blockHeight': blockHeight,
+          'meta.deleted': {
+            $exists: false
+          },
+          'meta.consensus': {
+            $exists: true
+          }
+        };
+        if(consensus === false) {
+          query['meta.consensus'].$exists = false;
+        }
+        const projection = {};
+        this.collection.findOne(query, projection, (err, record) => {
+          if(err) {
+            return callback(err);
+          }
+          if(!record) {
+            return callback(new BedrockError(
+              'A block with the given block height does not exist.',
+              'NotFoundError', {blockHeight}));
+          }
+          return callback(null, record);
+        });
       },
-      'meta.consensus': {
-        $exists: true
-      }
-    };
-    if(consensus === false) {
-      query['meta.consensus'].$exists = false;
-    }
-    const projection = {};
-    if(!eventHash) {
-      projection['block.event'] = 0;
-    }
-    this.collection.findOne(query, projection, (err, result) => {
+      eventHashes: ['find', (results, callback) => {
+        if(!eventHash) {
+          return callback();
+        }
+        // FIXME: this might be accomplished with aggregate query
+        // get event hashes
+        const block = results.find.block;
+        const query = {'meta.blockHeight': block.blockHeight};
+        const projection = {_id: 0, 'meta.eventHash': 1};
+        this.eventCollection.find(query, projection)
+          .sort({'meta.blockOrder': 1})
+          .toArray((err, eventHashes) => {
+            if(err) {
+              return callback(err);
+            }
+            block.eventHash = eventHashes.map(r => r.meta.eventHash);
+            callback();
+          });
+      }]
+    }, (err, results) => {
       if(err) {
         return callback(err);
       }
-      if(!result) {
-        return callback(new BedrockError(
-          'A block with the given block height does not exist.',
-          'NotFoundError', {blockHeight}));
-      }
-      if(result.block.event) {
-        result.block.eventHash = result.block.event;
-        delete result.block.event;
-      }
-      callback(null, {block: result.block, meta: result.meta});
+      callback(
+        null, {block: results.find.block, meta: results.find.meta});
     });
   }
 

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -597,23 +597,26 @@ module.exports = class LedgerBlockStorage {
     }, callback);
   }
 
+  // FIXME: this might be accomplished with aggregate query
   _expandEvents(block, callback) {
     block.event = [];
     const query = {'meta.blockHeight': block.blockHeight};
     const projection = {_id: 0, 'meta.eventHash': 1};
-    this.eventCollection.find(query, projection).toArray((err, eventHashes) => {
-      if(err) {
-        return callback(err);
-      }
-      eventHashes = eventHashes.map(r => r.meta.eventHash);
-      this.eventStorage.getMany({eventHashes}).sort({'meta.blockOrder': 1})
-        .toArray((err, events) => {
-          if(err) {
-            return callback(err);
+    this.eventCollection.find(query, projection)
+      .sort({'meta.blockOrder': 1})
+      .toArray((err, eventHashes) => {
+        if(err) {
+          return callback(err);
+        }
+        eventHashes = eventHashes.map(r => r.meta.eventHash);
+        // NOTE: getMany preserves order of hashes
+        this.eventStorage.getMany({eventHashes}).forEach(({event}) => {
+          if(event.type !== 'WebLedgerOperationEvent') {
+            // must strip operation
+            delete event.operation;
           }
-          block.event = events.map(r => r.event);
-          callback();
-        });
-    });
+          block.event.push(event);
+        }, callback);
+      });
   }
 };

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -74,7 +74,6 @@ module.exports = class LedgerBlockStorage {
         });
       },
       update: ['insert', (results, callback) => {
-        // FIXME: some tests are sending in hashes as strings
         async.timesLimit(event.length, 100, (i, callback) => {
           const query = {eventHash: event[i]};
           this.eventCollection.update(

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -166,7 +166,7 @@ module.exports = class LedgerEventStorage {
    */
   // consensus === undefined means ignore consensus
   getCount({consensus}, callback) {
-    if(!callback && typeof(callback) === 'function') {
+    if(!callback && typeof callback === 'function') {
       throw new TypeError('`callback` must be a function.');
     }
     const query = {

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -166,7 +166,7 @@ module.exports = class LedgerEventStorage {
    */
   // consensus === undefined means ignore consensus
   getCount({consensus}, callback) {
-    if(!callback && typeof callback === 'function') {
+    if(!(callback && typeof callback === 'function')) {
       throw new TypeError('`callback` must be a function.');
     }
     const query = {

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -168,16 +168,16 @@ module.exports = class LedgerEventStorage {
         eventHash: {$in: eventHashes},
       }},
       {$lookup:
-         {
-           from: operationCollectionName,
-           let: {eventHash: '$eventHash'},
-           pipeline: [
-             {$match: {$expr: {$eq: ['$meta.eventHash', '$$eventHash']}}},
-             {$sort: {'meta.eventOrder': 1}},
-             {$replaceRoot: {newRoot: "$operation"}}
-           ],
-           as: 'event.operation'
-         }
+        {
+          from: operationCollectionName,
+          let: {eventHash: '$eventHash'},
+          pipeline: [
+            {$match: {$expr: {$eq: ['$meta.eventHash', '$$eventHash']}}},
+            {$sort: {'meta.eventOrder': 1}},
+            {$replaceRoot: {newRoot: "$operation"}}
+          ],
+          as: 'event.operation'
+        }
       },
       {$addFields: {_order: {$indexOfArray: [eventHashes, '$eventHash']}}},
       {$sort: {'_order': 1}},

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -197,6 +197,9 @@ module.exports = class LedgerEventStorage {
     this.collection.find(query).count(callback);
   }
 
+  // FIXME: this seems like a very expensive operation and I don't think
+  // this API is in use anywhere, should it be removed?
+
   /**
    * Gets all event hashes that match the given query.
    *

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -401,7 +401,8 @@ module.exports = class LedgerEventStorage {
         });
       },
       update: ['buildUpdate', (results, callback) => this.collection.update(
-        {eventHash}, results.buildUpdate, database.writeOptions, callback)],
+        {eventHash: database.hash(eventHash)},
+        results.buildUpdate, database.writeOptions, callback)],
       checkUpdate: ['update', (results, callback) => {
         if(results.update.result.n === 0) {
           return callback(new BedrockError(

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -20,9 +20,9 @@ const BedrockError = bedrock.util.BedrockError;
  * with a particular ledger.
  */
 module.exports = class LedgerEventStorage {
-  constructor(options) {
+  constructor({eventCollection}) {
     // assign the collection used for event storage
-    this.collection = options.eventCollection;
+    this.collection = eventCollection;
   }
 
   /**
@@ -32,28 +32,18 @@ module.exports = class LedgerEventStorage {
    * event - the event to associate with a ledger.
    * meta - the metadata that is associated with the event.
    *   eventHash - the hash of the event data.
-   * options - a set of options used when creating the event.
    * callback(err, result) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   result - the result of the operation.
    *     event - the event that was committed to storage.
    *     meta - the metadata that was committed to storage.
    */
-  add(event, meta, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
+  add({event, meta}, callback) {
     if(!(event && _.isObject(event))) {
       throw new TypeError('`event` must be an object.');
     }
-    if(!(meta && _.isObject(meta))) {
-      throw new TypeError('`meta` must be an object.');
-    }
-    if(!meta.eventHash) {
-      return callback(new BedrockError(
-        'An event hash for the given event was not specified.',
-        'DataError', {meta: meta}));
+    if(!(meta && meta.eventHash)) {
+      throw new TypeError('`meta.eventHash` is required.');
     }
 
     // insert the event
@@ -131,19 +121,13 @@ module.exports = class LedgerEventStorage {
    * options.
    *
    * eventHash - the hash of the event to fetch from storage.
-   * options - a set of options used when retrieving the event.
    * callback(err, result) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   result - the result of the retrieval
    *     event - the event.
    *     meta - metadata about the event.
    */
-  get(eventHash, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  get(eventHash, callback) {
     async.auto({
       find: callback => {
         // find an existing block with consensus
@@ -181,73 +165,16 @@ module.exports = class LedgerEventStorage {
    *   consensus - filter events based on consensus status.
    * @param callback(err, count) - the callback to call when finished.
    */
-  getCount(options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
+  getCount({consensus}, callback) {
     const query = {
       'meta.deleted': {
         $exists: false
       }
     };
-    if(typeof options.consensus === 'boolean') {
-      query['meta.consensus'] = {$exists: options.consensus};
+    if(typeof consensus === 'boolean') {
+      query['meta.consensus'] = {$exists: consensus};
     }
     this.collection.find(query).count(callback);
-  }
-
-  // FIXME: this seems like a very expensive operation and I don't think
-  // this API is in use anywhere, should it be removed?
-
-  /**
-   * Gets all event hashes that match the given query.
-   *
-   * TODO: add option to get an iterator instead of an array response
-   *
-   * options - a set of options used when retrieving the event.
-   * callback(err, hashes) - the callback to call when finished.
-   *   err - An Error if an error occurred, null otherwise.
-   *   hashes - an array of event hashes that match the query.
-   */
-  getHashes(options, callback) {
-    const collection = this.collection;
-
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
-    const query = {
-      'meta.deleted': {
-        $exists: false
-      }
-    };
-    /* Note: There is an undocumented assumption that hashes will always
-    be URLs that uniquely identify how they were calculated via scheme
-    information. If this information is not present, then two different
-    consensus methods could produce the same hash value using different
-    mechanisms causing trouble. */
-    // TODO: support an option to filter particular schemes for hashes?
-    if(typeof options.consensus === 'boolean') {
-      query['meta.consensus'] = {$exists: options.consensus};
-    }
-    // FIXME: is sort needed?  If so, an index on meta.eventHash is needed
-    const queryOpts = {
-      sort: {'meta.eventHash': 1}
-    };
-    if(typeof options.limit === 'number') {
-      queryOpts.limit = options.limit;
-    }
-    const projection = {_id: 0, 'meta.eventHash': 1};
-    const hashes = [];
-    collection.find(query, projection, queryOpts)
-      .forEach(doc => hashes.push(doc.meta.eventHash), err => {
-        if(err) {
-          return callback(err);
-        }
-        callback(null, hashes);
-      });
   }
 
   /**
@@ -260,12 +187,7 @@ module.exports = class LedgerEventStorage {
    *     event - the event.
    *     meta - metadata about the event.
    */
-  getLatestConfig(options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  getLatestConfig(callback) {
     async.auto({
       find: callback => {
         // find the latest config event that has consensus
@@ -273,9 +195,7 @@ module.exports = class LedgerEventStorage {
           'event.type': 'WebLedgerConfigurationEvent',
           'meta.deleted': {$exists: false},
         };
-        // FIXME: sort should be done by block height, not by date
-        // FIXME: need to add `blockHeight` to meta in events to enable this
-        //   and then add an `event.type`+`meta.foo.blockHeight` index
+        // TODO: secondary sort by eventOrder?
         this.collection.find(query).sort({
           'meta.blockHeight': -1
         }).limit(1).toArray(callback);
@@ -299,17 +219,11 @@ module.exports = class LedgerEventStorage {
    *
    * eventHash - the ID of the event to update
    * patch - a list of patch commands for the event
-   * options - a set of options used when updating the event.
    * callback(err, result) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    *   result - the value of the updated event.
    */
-  update(eventHash, patch, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  update({eventHash, patch}, callback) {
     if(!Array.isArray(patch)) {
       throw new TypeError('patch must be an array');
     }
@@ -318,8 +232,6 @@ module.exports = class LedgerEventStorage {
       buildUpdate: callback => {
         const setObject = {};
         const unsetObject = {};
-        const setFields = {};
-        const unsetFields = {};
         const pushFields = {};
         const pullFields = {};
 
@@ -413,12 +325,7 @@ module.exports = class LedgerEventStorage {
    * callback(err) - the callback to call when finished.
    *   err - An Error if an error occurred, null otherwise.
    */
-  remove(eventHash, options, callback) {
-    if(typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
+  remove(eventHash, callback) {
     async.auto({
       update: callback => {
         // find and delete the existing event

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -59,11 +59,7 @@ module.exports = class LedgerEventStorage {
     // insert the event
     const now = Date.now();
     const record = {
-      // TODO: remove duplication of eventHash here -- we no longer
-      //   database.hash() it because we need guarantees that it
-      //   is a certain size anyway, so there's no reason to double hash
-      //   which means we don't need this extra field on the record
-      eventHash: meta.eventHash,
+      eventHash: database.hash(meta.eventHash),
       event: event,
       meta: _.defaults(meta, {
         created: now,
@@ -99,17 +95,19 @@ module.exports = class LedgerEventStorage {
    */
   difference(eventHash, callback) {
     const hashes = [].concat(eventHash);
+    const _hashes = hashes.map(h => database.hash(h));
     const query = {
       'meta.deleted': {$exists: false},
-      eventHash: {$in: hashes},
+      eventHash: {$in: _hashes},
     };
-    this.collection.find(query, {eventHash: 1}).toArray((err, result) => {
-      if(err) {
-        return callback(err);
-      }
-      const localEvents = result.map(e => e.eventHash);
-      callback(null, hashes.filter(v => !localEvents.includes(v)));
-    });
+    this.collection.find(query, {_id: 0, 'meta.eventHash': 1})
+      .toArray((err, result) => {
+        if(err) {
+          return callback(err);
+        }
+        const localEvents = new Set(result.map(e => e.meta.eventHash));
+        callback(null, hashes.filter(v => !localEvents.has(v)));
+      });
   }
 
   /**
@@ -119,7 +117,7 @@ module.exports = class LedgerEventStorage {
    * @param callback(err, result) called once the operation completes.
    */
   exists(eventHash, callback) {
-    const hashes = [].concat(eventHash);
+    const hashes = [].concat(eventHash).map(h => database.hash(h));
     const query = {
       'meta.deleted': {$exists: false},
       eventHash: {$in: hashes},
@@ -150,7 +148,7 @@ module.exports = class LedgerEventStorage {
       find: callback => {
         // find an existing block with consensus
         const query = {
-          eventHash: eventHash,
+          eventHash: database.hash(eventHash),
           'meta.deleted': {
             $exists: false
           }
@@ -231,16 +229,17 @@ module.exports = class LedgerEventStorage {
     if(typeof options.consensus === 'boolean') {
       query['meta.consensus'] = {$exists: options.consensus};
     }
+    // FIXME: is sort needed?  If so, an index on meta.eventHash is needed
     const queryOpts = {
-      sort: {eventHash: 1}
+      sort: {'meta.eventHash': 1}
     };
     if(typeof options.limit === 'number') {
       queryOpts.limit = options.limit;
     }
-    const projection = {_id: 0, eventHash: 1};
+    const projection = {_id: 0, 'meta.eventHash': 1};
     const hashes = [];
     collection.find(query, projection, queryOpts)
-      .forEach(doc => hashes.push(doc.eventHash), err => {
+      .forEach(doc => hashes.push(doc.meta.eventHash), err => {
         if(err) {
           return callback(err);
         }
@@ -389,12 +388,13 @@ module.exports = class LedgerEventStorage {
         });
       },
       update: ['buildUpdate', (results, callback) => this.collection.update(
-        {eventHash}, results.buildUpdate, database.writeOptions, callback)],
+        {eventHash: database.hash(eventHash)},
+        results.buildUpdate, database.writeOptions, callback)],
       checkUpdate: ['update', (results, callback) => {
         if(results.update.result.n === 0) {
           return callback(new BedrockError(
             'Could not update event. Event with given hash not found.',
-            'NotFoundError', {eventHash: eventHash}));
+            'NotFoundError', {eventHash}));
         }
         callback();
       }]
@@ -420,7 +420,7 @@ module.exports = class LedgerEventStorage {
       update: callback => {
         // find and delete the existing event
         const filter = {
-          eventHash: eventHash
+          eventHash: database.hash(eventHash)
         };
         const now = Date.now();
         const update = {
@@ -436,7 +436,7 @@ module.exports = class LedgerEventStorage {
       ensureUpdate: ['update', (results, callback) => {
         if(results.update.matchedCount !== 1) {
           return callback(new BedrockError(
-            'Delete of event failed.', 'NotFoundError', {eventHash: eventHash}
+            'Delete of event failed.', 'NotFoundError', {eventHash}
           ));
         }
         callback();

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -146,14 +146,14 @@ module.exports = class LedgerEventStorage {
     const hashes = [].concat(eventHash);
     const query = {
       'meta.deleted': {$exists: false},
-      eventHash: {$in: hashes},
+      eventHash: {$in: hashes.map(h => database.hash(h))},
     };
-    this.collection.find(query, {_id: 0, eventHash: 1})
+    this.collection.find(query, {_id: 0, 'meta.eventHash': 1})
       .toArray((err, result) => {
         if(err) {
           return callback(err);
         }
-        const localEvents = new Set(result.map(({eventHash}) => eventHash));
+        const localEvents = new Set(result.map(r => r.meta.eventHash));
         callback(null, hashes.filter(v => !localEvents.has(v)));
       });
   }

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -277,7 +277,7 @@ module.exports = class LedgerEventStorage {
         // FIXME: need to add `blockHeight` to meta in events to enable this
         //   and then add an `event.type`+`meta.foo.blockHeight` index
         this.collection.find(query).sort({
-          'meta.consensusDate': -1
+          'meta.blockHeight': -1
         }).limit(1).toArray(callback);
       }
     }, (err, results) => {

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -181,7 +181,7 @@ module.exports = class LedgerEventStorage {
       {$addFields: {_order: {$indexOfArray: [eventHashes, '$eventHash']}}},
       {$sort: {'_order': 1}},
       {$project: {_id: 0, _order: 0}},
-    ]);
+    ], {allowDiskUse: true});
   }
 
   /**
@@ -232,7 +232,7 @@ module.exports = class LedgerEventStorage {
            as: 'event.operation'
          }
       },
-    ]).toArray((err, result) => {
+    ], {allowDiskUse: true}).toArray((err, result) => {
       if(err) {
         return callback(err);
       }

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -164,7 +164,11 @@ module.exports = class LedgerEventStorage {
    *   consensus - filter events based on consensus status.
    * @param callback(err, count) - the callback to call when finished.
    */
+  // consensus === undefined means ignore consensus
   getCount({consensus}, callback) {
+    if(!callback && typeof(callback) === 'function') {
+      throw new TypeError('`callback` must be a function.');
+    }
     const query = {
       'meta.deleted': {
         $exists: false

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -159,8 +159,9 @@ module.exports = class LedgerEventStorage {
   }
 
   // return records in the same order as the request
-  // FIXME: `eventoperation` must be removed from merge events
+  // FIXME: `event.operation` must be removed from merge events
   getMany({eventHashes}) {
+    eventHashes = eventHashes.map(h => database.hash(h));
     const operationCollectionName = this.operationStorage.collection.s.name;
     return this.collection.aggregate([
       {$match: {
@@ -169,7 +170,7 @@ module.exports = class LedgerEventStorage {
       {$lookup:
          {
            from: operationCollectionName,
-           let: {'eventHash': '$eventHash'},
+           let: {eventHash: '$eventHash'},
            pipeline: [
              {$match: {$expr: {$eq: ['$meta.eventHash', '$$eventHash']}}},
              {$sort: {'meta.eventOrder': 1}},
@@ -191,7 +192,7 @@ module.exports = class LedgerEventStorage {
    * @param callback(err, result) called once the operation completes.
    */
   exists(eventHash, callback) {
-    const hashes = [].concat(eventHash);
+    const hashes = [].concat(eventHash).map(h => database.hash(h));
     const query = {
       'meta.deleted': {$exists: false},
       eventHash: {$in: hashes},
@@ -213,7 +214,7 @@ module.exports = class LedgerEventStorage {
   get(eventHash, callback) {
     const operationCollectionName = this.operationStorage.collection.s.name;
     const query = {
-      eventHash,
+      eventHash: database.hash(eventHash),
       'meta.deleted': {
         $exists: false
       }
@@ -221,16 +222,16 @@ module.exports = class LedgerEventStorage {
     this.collection.aggregate([
       {$match: query},
       {$lookup:
-         {
-           from: operationCollectionName,
-           let: {'eventHash': '$eventHash'},
-           pipeline: [
-             {$match: {$expr: {$eq: ['$meta.eventHash', '$$eventHash']}}},
-             {$sort: {'meta.eventOrder': 1}},
-             {$replaceRoot: {newRoot: "$operation"}}
-           ],
-           as: 'event.operation'
-         }
+        {
+          from: operationCollectionName,
+          let: {eventHash: '$eventHash'},
+          pipeline: [
+            {$match: {$expr: {$eq: ['$meta.eventHash', '$$eventHash']}}},
+            {$sort: {'meta.eventOrder': 1}},
+            {$replaceRoot: {newRoot: "$operation"}}
+          ],
+          as: 'event.operation'
+        }
       },
     ], {allowDiskUse: true}).toArray((err, result) => {
       if(err) {

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -85,17 +85,16 @@ module.exports = class LedgerEventStorage {
    */
   difference(eventHash, callback) {
     const hashes = [].concat(eventHash);
-    const _hashes = hashes.map(h => database.hash(h));
     const query = {
       'meta.deleted': {$exists: false},
-      eventHash: {$in: _hashes},
+      eventHash: {$in: hashes},
     };
-    this.collection.find(query, {_id: 0, 'meta.eventHash': 1})
+    this.collection.find(query, {_id: 0, eventHash: 1})
       .toArray((err, result) => {
         if(err) {
           return callback(err);
         }
-        const localEvents = new Set(result.map(e => e.meta.eventHash));
+        const localEvents = new Set(result.map(({eventHash}) => eventHash));
         callback(null, hashes.filter(v => !localEvents.has(v)));
       });
   }
@@ -107,7 +106,7 @@ module.exports = class LedgerEventStorage {
    * @param callback(err, result) called once the operation completes.
    */
   exists(eventHash, callback) {
-    const hashes = [].concat(eventHash).map(h => database.hash(h));
+    const hashes = [].concat(eventHash);
     const query = {
       'meta.deleted': {$exists: false},
       eventHash: {$in: hashes},
@@ -227,7 +226,6 @@ module.exports = class LedgerEventStorage {
     if(!Array.isArray(patch)) {
       throw new TypeError('patch must be an array');
     }
-
     async.auto({
       buildUpdate: callback => {
         const setObject = {};
@@ -303,8 +301,7 @@ module.exports = class LedgerEventStorage {
         });
       },
       update: ['buildUpdate', (results, callback) => this.collection.update(
-        {eventHash: database.hash(eventHash)},
-        results.buildUpdate, database.writeOptions, callback)],
+        {eventHash}, results.buildUpdate, database.writeOptions, callback)],
       checkUpdate: ['update', (results, callback) => {
         if(results.update.result.n === 0) {
           return callback(new BedrockError(

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -131,7 +131,7 @@ module.exports = class LedgerEventStorage {
       find: callback => {
         // find an existing block with consensus
         const query = {
-          eventHash: database.hash(eventHash),
+          eventHash,
           'meta.deleted': {
             $exists: false
           }

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -20,9 +20,10 @@ const BedrockError = bedrock.util.BedrockError;
  * with a particular ledger.
  */
 module.exports = class LedgerEventStorage {
-  constructor({eventCollection}) {
+  constructor({eventCollection, operationStorage}) {
     // assign the collection used for event storage
     this.collection = eventCollection;
+    this.operationStorage = operationStorage;
   }
 
   /**
@@ -45,7 +46,8 @@ module.exports = class LedgerEventStorage {
     if(!(meta && meta.eventHash)) {
       throw new TypeError('`meta.eventHash` is required.');
     }
-
+    const operations = event.operation;
+    delete event.operation;
     // insert the event
     const now = Date.now();
     const record = {
@@ -58,23 +60,80 @@ module.exports = class LedgerEventStorage {
     };
 
     logger.verbose(`adding event: ${meta.eventHash}`);
-
-    this.collection.insert(
-      record, database.writeOptions, (err, result) => {
-        if(err && database.isDuplicateError(err)) {
-          return callback(new BedrockError(
-            'An event with the same hash already exists.',
-            'DuplicateError', {
-              httpStatusCode: 409,
-              public: true,
-              eventHash: meta.eventHash
-            }, err.message));
+    // TODO: acid magic
+    async.auto({
+      insert: callback => this.collection.insert(
+        record, database.writeOptions, (err, result) => {
+          if(err && database.isDuplicateError(err)) {
+            return callback(new BedrockError(
+              'An event with the same hash already exists.',
+              'DuplicateError', {
+                httpStatusCode: 409,
+                public: true,
+                eventHash: meta.eventHash
+              }, err.message));
+          }
+          if(err) {
+            return callback(err);
+          }
+          callback(null, {
+            event: result.ops[0].event,
+            meta: result.ops[0].meta
+          });
+        }),
+      // FIXME: events have been ordered by database.hash
+      operation: ['insert', (results, callback) => {
+        if(!operations) {
+          return callback();
         }
+        const records = [];
+        for(let i = 0; i < operations.length; ++i) {
+          const {eventHash} = record;
+          const _meta = {
+            eventOrder: i,
+            eventHash
+          };
+          const operation = operations[i];
+          // FIXME: is a hash of the operation needed here?
+          records.push({
+            meta: _meta,
+            operation
+          });
+        }
+        this.operationStorage.addMany({operations: records}, callback);
+      }]
+    }, (err, results) => {
+      if(err) {
+        return callback(err);
+      }
+      callback(null, results.insert);
+    });
+  }
+
+  // TODO: add docs
+  addMany({events}, callback) {
+    const dupHashes = [];
+    async.retry({
+      times: Infinity, errorFilter: database.isDuplicateError
+    }, callback => this.collection.insertMany(
+      events, {ordered: true}, err => {
         if(err) {
+          if(database.isDuplicateError(err)) {
+            // remove events up to the dup and retry
+            dupHashes.push(events[err.index].eventHash);
+            events.splice(0, err.index + 1);
+            return callback(err);
+          }
           return callback(err);
         }
-        callback(null, {event: result.ops[0].event, meta: result.ops[0].meta});
-      });
+        callback();
+      }),
+    err => {
+      if(err) {
+        return callback(err);
+      }
+      callback(null, {dupHashes});
+    });
   }
 
   /**
@@ -99,6 +158,32 @@ module.exports = class LedgerEventStorage {
       });
   }
 
+  // return records in the same order as the request
+  // FIXME: `eventoperation` must be removed from merge events
+  getMany({eventHashes}) {
+    const operationCollectionName = this.operationStorage.collection.s.name;
+    return this.collection.aggregate([
+      {$match: {
+        eventHash: {$in: eventHashes},
+      }},
+      {$lookup:
+         {
+           from: operationCollectionName,
+           let: {'eventHash': '$eventHash'},
+           pipeline: [
+             {$match: {$expr: {$eq: ['$meta.eventHash', '$$eventHash']}}},
+             {$sort: {'meta.eventOrder': 1}},
+             {$replaceRoot: {newRoot: "$operation"}}
+           ],
+           as: 'event.operation'
+         }
+      },
+      {$addFields: {_order: {$indexOfArray: [eventHashes, '$eventHash']}}},
+      {$sort: {'_order': 1}},
+      {$project: {_id: 0, _order: 0}},
+    ]);
+  }
+
   /**
    * Determine if an event with a given hash exists.
    *
@@ -116,8 +201,7 @@ module.exports = class LedgerEventStorage {
   }
 
   /**
-   * Gets one or more events in the ledger given a query and a set of
-   * options.
+   * Gets an event in the ledger given a query and a set of options.
    *
    * eventHash - the hash of the event to fetch from storage.
    * callback(err, result) - the callback to call when finished.
@@ -127,23 +211,32 @@ module.exports = class LedgerEventStorage {
    *     meta - metadata about the event.
    */
   get(eventHash, callback) {
-    async.auto({
-      find: callback => {
-        // find an existing block with consensus
-        const query = {
-          eventHash,
-          'meta.deleted': {
-            $exists: false
-          }
-        };
-        this.collection.findOne(query, callback);
+    const operationCollectionName = this.operationStorage.collection.s.name;
+    const query = {
+      eventHash,
+      'meta.deleted': {
+        $exists: false
       }
-    }, (err, results) => {
+    };
+    this.collection.aggregate([
+      {$match: query},
+      {$lookup:
+         {
+           from: operationCollectionName,
+           let: {'eventHash': '$eventHash'},
+           pipeline: [
+             {$match: {$expr: {$eq: ['$meta.eventHash', '$$eventHash']}}},
+             {$sort: {'meta.eventOrder': 1}},
+             {$replaceRoot: {newRoot: "$operation"}}
+           ],
+           as: 'event.operation'
+         }
+      },
+    ]).toArray((err, result) => {
       if(err) {
         return callback(err);
       }
-
-      if(!results.find) {
+      if(!result || result.length === 0) {
         return callback(new BedrockError(
           'Failed to get event. An event with the given ID does not exist.',
           'NotFoundError', {
@@ -152,8 +245,11 @@ module.exports = class LedgerEventStorage {
             eventHash
           }));
       }
-
-      callback(null, {event: results.find.event, meta: results.find.meta});
+      const {event, meta} = result[0];
+      if(event.type !== 'WebLedgerOperationEvent') {
+        delete event.operation;
+      }
+      callback(null, {event, meta});
     });
   }
 

--- a/lib/ledgerOperationStorage.js
+++ b/lib/ledgerOperationStorage.js
@@ -1,0 +1,35 @@
+/*!
+ * Ledger block storage class.
+ *
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+// const _ = require('lodash');
+// const async = require('async');
+// const bedrock = require('bedrock');
+// const database = require('bedrock-mongodb');
+// const logger = require('./logger');
+// const {BedrockError} = bedrock.util;
+
+/**
+ * The operation API is used to perform operations on operationsassociated with
+ * a particular event.
+ */
+module.exports = class LedgerOperationStorage {
+  constructor({operationCollection}) {
+    this.collection = operationCollection;
+  }
+
+  addMany({operations}, callback) {
+    this.collection.insertMany(operations, {ordered: false}, err => {
+      // TODO: inspect result for dups etc, non-ordered insert does not
+      // err on duplicates, it returns dup info in the result
+      // what is the situation with dups and operations?
+      if(err) {
+        return callback(err);
+      }
+      callback();
+    });
+  }
+};

--- a/lib/ledgerStateMachineStorage.js
+++ b/lib/ledgerStateMachineStorage.js
@@ -63,7 +63,7 @@ module.exports = class LedgerStateMachineStorage {
         const now = Date.now();
         const update = {
           id: database.hash(object.id),
-          object: object,
+          object,
           meta: _.defaults(meta, {
             created: now,
             updated: now
@@ -151,13 +151,12 @@ module.exports = class LedgerStateMachineStorage {
             $exists: true
           }
         };
-
-        this.collection.find(query).sort(
-          {'meta.blockHeight': -1}).limit(1).toArray(results => {
-          if(results === null) {
+        this.collection.find(query, {_id: 0, 'meta.blockHeight': 1}).sort(
+          {'meta.blockHeight': -1}).limit(1).toArray((err, records) => {
+          if(records.length === 0) {
             return callback(null, 0);
           }
-          callback(null, results[0].block.blockHeight);
+          callback(null, records[0].meta.blockHeight);
         });
       },
       replayEvents: [
@@ -191,16 +190,15 @@ module.exports = class LedgerStateMachineStorage {
       async.auto({
         getEvent: callback => {
           // If input is a ni:/// hash, fetch it from event storage
-          if(typeof(event) === 'string' && event.startsWith('ni:///')) {
-            this.eventStorage.get(event, {}, (err, result) => {
+          if(typeof event === 'string' && event.startsWith('ni:///')) {
+            return this.eventStorage.get(event, (err, result) => {
               if(err) {
                 return callback(err);
               }
               callback(null, result.event);
             });
-          } else {
-            callback(null, event);
           }
+          callback(null, event);
         },
         updateStateMachine: ['getEvent', (results, callback) => {
           // update the state machine by processing all inputs

--- a/lib/ledgerStateMachineStorage.js
+++ b/lib/ledgerStateMachineStorage.js
@@ -160,22 +160,23 @@ module.exports = class LedgerStateMachineStorage {
           callback(null, results[0].block.blockHeight);
         });
       },
-      replayEvents: ['getLatestBlockHeight', 'getStateMachineBlockHeight',
+      replayEvents: [
+        'getLatestBlockHeight', 'getStateMachineBlockHeight',
         (results, callback) => {
-        const latestBlockHeight =
-          results.getLatestBlockHeight.eventBlock.block.blockHeight;
-        let smBlockHeight = results.getStateMachineBlockHeight;
-        async.until(
-          () => (smBlockHeight > latestBlockHeight), callback => {
-            this.blockStorage.getByHeight(smBlockHeight, (err, record) => {
-              if(err) {
-                return callback(err);
-              }
-              smBlockHeight++;
-              this._updateStateMachineWithBlock(record.block, callback);
-            });
-        }, err => callback(err));
-      }]
+          const latestBlockHeight =
+            results.getLatestBlockHeight.eventBlock.block.blockHeight;
+          let smBlockHeight = results.getStateMachineBlockHeight;
+          async.until(
+            () => (smBlockHeight > latestBlockHeight), callback => {
+              this.blockStorage.getByHeight(smBlockHeight, (err, record) => {
+                if(err) {
+                  return callback(err);
+                }
+                smBlockHeight++;
+                this._updateStateMachineWithBlock(record.block, callback);
+              });
+            }, err => callback(err));
+        }]
     }, err => callback(err));
   }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "bedrock": "^1.8.0",
     "bedrock-ledger-node": "digitalbazaar/bedrock-ledger-node#master",
-    "bedrock-mongodb": "^4.0.0"
+    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#5.x"
   },
   "engines": {
     "node": ">=6.3.0"

--- a/test/mocha/20-block-api.js
+++ b/test/mocha/20-block-api.js
@@ -51,6 +51,7 @@ describe('Block Storage API', () => {
           meta.blockHash = results.blockHash;
           meta.consensus = true;
           meta.consensusDate = Date.now();
+          block.blockHeight = 0;
           block.event = [results.eventHash];
           ledgerStorage.blocks.add({block, meta}, callback);
         }]
@@ -106,6 +107,7 @@ describe('Block Storage API', () => {
         addAgain: ['add', (results, callback) => {
           const {block} = results.create.blocks[0];
           const {meta} = results.create.blocks[0];
+          console.log('BBBBBBBB', block);
           ledgerStorage.blocks.add({block, meta}, callback);
         }]
       }, (err) => {

--- a/test/mocha/20-block-api.js
+++ b/test/mocha/20-block-api.js
@@ -43,7 +43,7 @@ describe('Block Storage API', () => {
           consensusDate: Date.now(),
           eventHash: results.eventHash
         };
-        ledgerStorage.events.add(configEventTemplate, meta, callback);
+        ledgerStorage.events.add({event: configEventTemplate, meta}, callback);
       }],
       addConfigBlock: [
         'initStorage', 'blockHash', 'eventHash', (results, callback) => {
@@ -107,7 +107,6 @@ describe('Block Storage API', () => {
         addAgain: ['add', (results, callback) => {
           const {block} = results.create.blocks[0];
           const {meta} = results.create.blocks[0];
-          console.log('BBBBBBBB', block);
           ledgerStorage.blocks.add({block, meta}, callback);
         }]
       }, (err) => {
@@ -134,7 +133,7 @@ describe('Block Storage API', () => {
         event: ['create', (results, callback) => {
           const event = results.create.events[0].event;
           const meta = results.create.events[0].meta;
-          ledgerStorage.events.add(event, meta, callback);
+          ledgerStorage.events.add({event, meta}, callback);
         }],
         get: ['block', 'event', (results, callback) =>
           ledgerStorage.blocks.get(block.id, (err, result) => {
@@ -192,7 +191,7 @@ describe('Block Storage API', () => {
         event: ['create', (results, callback) => {
           const {event} = results.create.events[0];
           const {meta} = results.create.events[0];
-          ledgerStorage.events.add(event, meta, callback);
+          ledgerStorage.events.add({event, meta}, callback);
         }],
         getAll: ['block', 'event', (results, callback) =>
           ledgerStorage.blocks.getAll(block.id, (err, iterator) => {
@@ -240,7 +239,7 @@ describe('Block Storage API', () => {
         event: ['create', (results, callback) => {
           const event = results.create.events[0].event;
           const meta = results.create.events[0].meta;
-          ledgerStorage.events.add(event, meta, callback);
+          ledgerStorage.events.add({event, meta}, callback);
         }],
         update: ['block', 'event', (results, callback) => {
           const patch = [{
@@ -325,7 +324,7 @@ describe('Block Storage API', () => {
         event: ['create', (results, callback) => {
           const event = results.create.events[0].event;
           const meta = results.create.events[0].meta;
-          ledgerStorage.events.add(event, meta, callback);
+          ledgerStorage.events.add({event, meta}, callback);
         }],
         delete: ['block', (results, callback) => {
           const {blockHash} = results.create.blocks[0].meta;
@@ -377,7 +376,7 @@ describe('Block Storage API', () => {
         event: ['create', (results, callback) => {
           const event = results.create.events[0].event;
           const meta = results.create.events[0].meta;
-          ledgerStorage.events.add(event, meta, callback);
+          ledgerStorage.events.add({event, meta}, callback);
         }],
         latest: ['block', 'event', (results, callback) =>
           ledgerStorage.blocks.getLatest((err, result) => {
@@ -410,7 +409,7 @@ describe('Block Storage API', () => {
         event: ['create', (results, callback) => {
           const event = results.create.events[0].event;
           const meta = results.create.events[0].meta;
-          ledgerStorage.events.add(event, meta, callback);
+          ledgerStorage.events.add({event, meta}, callback);
         }],
         summary: ['block', 'event', (results, callback) =>
           ledgerStorage.blocks.getLatestSummary((err, result) => {

--- a/test/mocha/20-block-api.js
+++ b/test/mocha/20-block-api.js
@@ -136,7 +136,7 @@ describe('Block Storage API', () => {
           ledgerStorage.events.add({event, meta}, callback);
         }],
         get: ['block', 'event', (results, callback) =>
-          ledgerStorage.blocks.get(block.id, (err, result) => {
+          ledgerStorage.blocks.get({blockId: block.id}, (err, result) => {
             assertNoError(err);
             should.exist(result.block);
             should.exist(result.meta);
@@ -158,7 +158,7 @@ describe('Block Storage API', () => {
           callback();
         }],
         get: ['block', (results, callback) => ledgerStorage.blocks.get(
-          block.id, (err, iterator) => {
+          {blockId: block.id}, (err, iterator) => {
             async.eachSeries(iterator, (promise, callback) => {
               promise.then(result => {
                 should.not.exist(result);
@@ -271,12 +271,11 @@ describe('Block Storage API', () => {
               }
             }
           }];
-
-          ledgerStorage.blocks.update(
-            results.create.blocks[0].meta.blockHash, patch, callback);
+          const {blockHash} = results.create.blocks[0].meta;
+          ledgerStorage.blocks.update({blockHash, patch}, callback);
         }],
         get: ['update', (results, callback) => {
-          ledgerStorage.blocks.get(block.id, callback);
+          ledgerStorage.blocks.get({blockId: block.id}, callback);
         }]
       }, (err, results) => {
         assertNoError(err);
@@ -299,7 +298,7 @@ describe('Block Storage API', () => {
             }
           }];
           ledgerStorage.blocks.update(
-            'bogusHash', patch, callback);
+            {blockHash: 'bogusHash', patch}, callback);
         }
       }, err => {
         should.exist(err);

--- a/test/mocha/20-block-api.js
+++ b/test/mocha/20-block-api.js
@@ -125,17 +125,17 @@ describe('Block Storage API', () => {
       async.auto({
         create: callback => helpers.createBlocks(
           {blockTemplate, eventTemplate}, callback),
-        block: ['create', (results, callback) => {
-          block = results.create.blocks[0].block;
-          const meta = results.create.blocks[0].meta;
-          ledgerStorage.blocks.add({block, meta}, callback);
-        }],
         event: ['create', (results, callback) => {
           const event = results.create.events[0].event;
           const meta = results.create.events[0].meta;
           ledgerStorage.events.add({event, meta}, callback);
         }],
-        get: ['block', 'event', (results, callback) =>
+        block: ['event', (results, callback) => {
+          block = results.create.blocks[0].block;
+          const meta = results.create.blocks[0].meta;
+          ledgerStorage.blocks.add({block, meta}, callback);
+        }],
+        get: ['block', (results, callback) =>
           ledgerStorage.blocks.get({blockId: block.id}, (err, result) => {
             assertNoError(err);
             should.exist(result.block);

--- a/test/mocha/30-event-api.js
+++ b/test/mocha/30-event-api.js
@@ -6,6 +6,7 @@
 const _ = require('lodash');
 const async = require('async');
 const blsMongodb = require('bedrock-ledger-storage-mongodb');
+const database = require('bedrock-mongodb');
 const helpers = require('./helpers');
 const mockData = require('./mock.data');
 const uuid = require('uuid/v4');
@@ -64,7 +65,7 @@ describe('Event Storage API', () => {
           should.exist(result.meta);
 
           // ensure the event was created in the database
-          const query = {eventHash: result.meta.eventHash};
+          const query = {eventHash: database.hash(result.meta.eventHash)};
           ledgerStorage.events.collection.findOne(query, callback);
         }],
         ensureEvent: ['ensureAdd', (results, callback) => {

--- a/test/mocha/30-event-api.js
+++ b/test/mocha/30-event-api.js
@@ -171,12 +171,11 @@ describe('Event Storage API', () => {
         add: ['hash', (results, callback) => ledgerStorage.events.add(
           {event, meta: {eventHash: results.hash}}, callback)],
         test: ['add', (results, callback) => {
-          ledgerStorage.events.exists(
-            database.hash(results.hash), (err, result) => {
-              assertNoError(err);
-              result.should.be.true;
-              callback();
-            });
+          ledgerStorage.events.exists(results.hash, (err, result) => {
+            assertNoError(err);
+            result.should.be.true;
+            callback();
+          });
         }]}, err => done(err));
     });
     it('returns true if multiple events exist', done => {
@@ -195,12 +194,11 @@ describe('Event Storage API', () => {
           callback)
         ],
         test: ['add', (results, callback) => {
-          ledgerStorage.events.exists(
-            results.hash.map(h => database.hash(h)), (err, result) => {
-              assertNoError(err);
-              result.should.be.true;
-              callback();
-            });
+          ledgerStorage.events.exists(results.hash, (err, result) => {
+            assertNoError(err);
+            result.should.be.true;
+            callback();
+          });
         }]}, err => done(err));
     });
     it('returns false if an event does not exist', done => {
@@ -223,7 +221,7 @@ describe('Event Storage API', () => {
           ledgerStorage.events.add({event, meta}, callback);
         }],
         get: ['add', (results, callback) => {
-          const eventHash = database.hash(results.add.meta.eventHash);
+          const eventHash = results.add.meta.eventHash;
           ledgerStorage.events.get(eventHash, callback);
         }]
       }, (err, results) => {
@@ -308,11 +306,11 @@ describe('Event Storage API', () => {
             }
           }];
 
-          const eventHash = database.hash(results.create.meta.eventHash);
+          const eventHash = results.create.meta.eventHash;
           ledgerStorage.events.update({eventHash, patch}, callback);
         }],
         get: ['update', (results, callback) => {
-          const eventHash = database.hash(results.create.meta.eventHash);
+          const eventHash = results.create.meta.eventHash;
           ledgerStorage.events.get(eventHash, callback);
         }]
       }, (err, results) => {

--- a/test/mocha/30-event-api.js
+++ b/test/mocha/30-event-api.js
@@ -47,6 +47,7 @@ describe('Event Storage API', () => {
           // blockHash and consensus are normally created by consensus plugin
           meta.blockHash = results.blockHash;
           meta.consensus = Date.now();
+          block.blockHeight = 0;
           block.event = [results.eventHash];
           ledgerStorage.blocks.add({block, meta}, callback);
         }]
@@ -239,7 +240,8 @@ describe('Event Storage API', () => {
   describe('getLatestConfig API', () => {
     it('should get latest config event', done => {
       const event = _.cloneDeep(configEventTemplate);
-      event.label = 'latest config event test';
+      // FIXME: how is uniqueness of ledgerConfigurations guaranteed?
+      event.ledgerConfiguration.consensusMethod = 'Continuity2017';
       const meta = {};
       const options = {};
 
@@ -247,6 +249,7 @@ describe('Event Storage API', () => {
         hash: callback => helpers.testHasher(event, callback),
         add: ['hash', (results, callback) => {
           meta.eventHash = results.hash;
+          meta.blockHeight = 10000000;
           meta.consensus = true;
           meta.consensusDate = Date.now();
           ledgerStorage.events.add(event, meta, callback);
@@ -256,7 +259,7 @@ describe('Event Storage API', () => {
         }],
         ensureGet: ['get', (results, callback) => {
           const configEvent = results.get;
-          configEvent.event.label.should.equal('latest config event test');
+          configEvent.event.should.deep.equal(event);
           callback();
         }]
       }, err => done(err));

--- a/test/mocha/30-event-api.js
+++ b/test/mocha/30-event-api.js
@@ -120,7 +120,7 @@ describe('Event Storage API', () => {
           ledgerStorage.events.add({event: events[i], meta}, callback);
         }, callback)],
         difference: ['add', (results, callback) => {
-          const expectedHashes = results.hash.map(h => database.hash(h));
+          const expectedHashes = results.hash;
           ledgerStorage.events.difference(expectedHashes, (err, result) => {
             assertNoError(err);
             should.exist(result);
@@ -150,14 +150,13 @@ describe('Event Storage API', () => {
             ledgerStorage.events.add({event, meta}, callback);
           }, callback)],
         difference: ['add', (results, callback) =>
-          ledgerStorage.events.difference(
-            results.hash.map(h => database.hash(h)), (err, result) => {
-              assertNoError(err);
-              should.exist(result);
-              result.should.be.an('array');
-              result.should.have.length(0);
-              callback();
-            })]
+          ledgerStorage.events.difference(results.hash, (err, result) => {
+            assertNoError(err);
+            should.exist(result);
+            result.should.be.an('array');
+            result.should.have.length(0);
+            callback();
+          })]
       }, done);
     });
   }); // end difference API

--- a/test/mocha/40-state-machine-api.js
+++ b/test/mocha/40-state-machine-api.js
@@ -42,7 +42,7 @@ describe('State Machine Storage API', () => {
           consensusDate: Date.now(),
           eventHash: results.eventHash
         };
-        ledgerStorage.events.add(configEventTemplate, meta, callback);
+        ledgerStorage.events.add({event: configEventTemplate, meta}, callback);
       }],
       addConfigBlock: [
         'initStorage', 'blockHash', 'eventHash', (results, callback) => {
@@ -74,7 +74,8 @@ describe('State Machine Storage API', () => {
         }),
       event: ['create', (results, callback) => {
         async.each(results.create.events, (e, callback) =>
-          ledgerStorage.events.add(e.event, e.meta, callback), callback);
+          ledgerStorage.events.add(
+            {event: e.event, meta: e.meta}, callback), callback);
       }],
       block: ['event', (results, callback) => {
         async.each(results.create.blocks, ({block, meta}, callback) =>

--- a/test/mocha/40-state-machine-api.js
+++ b/test/mocha/40-state-machine-api.js
@@ -60,7 +60,7 @@ describe('State Machine Storage API', () => {
     // FIXME: Remove ledger
     done();
   });
-  it.only('should get state machine object by id', done => {
+  it('should get state machine object by id', done => {
     const blockTemplate = eventBlockTemplate;
     const eventTemplate = mockData.events.alpha;
     let operation1;
@@ -107,7 +107,7 @@ describe('State Machine Storage API', () => {
       done(err);
     });
   });
-  it.only('should get two state machine objects from different blocks by id',
+  it('should get two state machine objects from different blocks by id',
     done => {
     const blockTemplate = eventBlockTemplate;
     const eventTemplate = mockData.events.alpha;

--- a/test/mocha/40-state-machine-api.js
+++ b/test/mocha/40-state-machine-api.js
@@ -60,7 +60,7 @@ describe('State Machine Storage API', () => {
     // FIXME: Remove ledger
     done();
   });
-  it('should get state machine object by id', done => {
+  it.only('should get state machine object by id', done => {
     const blockTemplate = eventBlockTemplate;
     const eventTemplate = mockData.events.alpha;
     let operation1;
@@ -98,6 +98,90 @@ describe('State Machine Storage API', () => {
         // recordOne.meta.blockHeight.should.equal(1);
         recordOne.object.should.deep.equal(operation1.record);
         const recordTwo = results.getTwo;
+        recordTwo.object.should.deep.equal(operation2.record);
+        recordOne.meta.blockHeight.should.equal(2);
+        callback();
+      }]
+    }, err => {
+      assertNoError(err);
+      done(err);
+    });
+  });
+  it.only('should get two state machine objects from different blocks by id',
+    done => {
+    const blockTemplate = eventBlockTemplate;
+    const eventTemplate = mockData.events.alpha;
+    let operation1;
+    let operation2;
+    async.auto({
+      create: callback => helpers.createBlocks(
+        {blockTemplate, eventTemplate, blockNum: 2}, (err, result) => {
+          operation1 = result.events[0].event.operation[0];
+          operation2 = result.events[1].event.operation[0];
+          callback(err, result);
+        }),
+      event: ['create', (results, callback) => {
+        async.each(results.create.events, (e, callback) =>
+          ledgerStorage.events.add(
+            {event: e.event, meta: e.meta}, callback), callback);
+      }],
+      block: ['event', (results, callback) => {
+        async.each(results.create.blocks, ({block, meta}, callback) =>
+          ledgerStorage.blocks.add({block, meta}, callback), callback);
+      }],
+      get: ['block', 'event', (results, callback) => {
+        ledgerStorage.stateMachine.get(operation1.record.id, callback);
+      }],
+      getTwo: ['get', (results, callback) => {
+        ledgerStorage.stateMachine.get(operation2.record.id, callback);
+      }],
+      ensureObject: ['get', 'getTwo', (results, callback) => {
+        const recordOne = results.get;
+        should.exist(recordOne);
+        should.exist(recordOne.object);
+        should.exist(recordOne.object.id);
+        should.exist(recordOne.meta);
+        should.exist(recordOne.meta.blockHeight);
+        // FIXME: should blockHeight equal the block that contains the event?
+        // recordOne.meta.blockHeight.should.equal(1);
+        recordOne.object.should.deep.equal(operation1.record);
+        const recordTwo = results.getTwo;
+        recordTwo.object.should.deep.equal(operation2.record);
+        recordOne.meta.blockHeight.should.equal(2);
+        callback();
+      }],
+      create2: ['ensureObject', (results, callback) => helpers.createBlocks(
+        {blockTemplate, eventTemplate, blockNum: 2}, (err, result) => {
+          operation1 = result.events[0].event.operation[0];
+          operation2 = result.events[1].event.operation[0];
+          callback(err, result);
+        })],
+      event2: ['create2', (results, callback) => {
+        async.each(results.create2.events, (e, callback) =>
+          ledgerStorage.events.add(
+            {event: e.event, meta: e.meta}, callback), callback);
+      }],
+      block2: ['event2', (results, callback) => {
+        async.each(results.create2.blocks, ({block, meta}, callback) =>
+          ledgerStorage.blocks.add({block, meta}, callback), callback);
+      }],
+      get2: ['block2', 'event2', (results, callback) => {
+        ledgerStorage.stateMachine.get(operation1.record.id, callback);
+      }],
+      getTwo2: ['get2', (results, callback) => {
+        ledgerStorage.stateMachine.get(operation2.record.id, callback);
+      }],
+      ensureObject2: ['get2', 'getTwo2', (results, callback) => {
+        const recordOne = results.get2;
+        should.exist(recordOne);
+        should.exist(recordOne.object);
+        should.exist(recordOne.object.id);
+        should.exist(recordOne.meta);
+        should.exist(recordOne.meta.blockHeight);
+        // FIXME: should blockHeight equal the block that contains the event?
+        // recordOne.meta.blockHeight.should.equal(1);
+        recordOne.object.should.deep.equal(operation1.record);
+        const recordTwo = results.getTwo2;
         recordTwo.object.should.deep.equal(operation2.record);
         recordOne.meta.blockHeight.should.equal(2);
         callback();

--- a/test/mocha/50-driver-api.js
+++ b/test/mocha/50-driver-api.js
@@ -47,6 +47,7 @@ describe('Ledger Storage Driver API', () => {
         // blockHash and consensus are normally created by consensus plugin
           meta.blockHash = results.blockHash;
           meta.consensus = Date.now();
+          block.blockHeight = 0;
           block.event = [results.eventHash];
           ledgerStorage.blocks.add({block, meta}, callback);
         }]

--- a/test/mocha/50-driver-api.js
+++ b/test/mocha/50-driver-api.js
@@ -40,7 +40,7 @@ describe('Ledger Storage Driver API', () => {
           consensusDate: Date.now(),
           eventHash: results.eventHash
         };
-        ledgerStorage.events.add(configEventTemplate, meta, callback);
+        ledgerStorage.events.add({event: configEventTemplate, meta}, callback);
       }],
       addConfigBlock: [
         'initStorage', 'blockHash', 'eventHash', (results, callback) => {

--- a/test/mocha/60-performance.js
+++ b/test/mocha/60-performance.js
@@ -21,7 +21,7 @@ describe('Performance tests', () => {
       done();
     });
   });
-  describe('Block', () => {
+  describe('Blocks and Event Operations', () => {
     const blockNum = 1000;
     const eventNum = 10;
     const opNum = 2500;
@@ -42,15 +42,8 @@ describe('Performance tests', () => {
         done();
       });
     });
-    it(`blocks.add ${blockNum} blocks`, function(done) {
-      this.timeout(320000);
-      async.eachLimit(blocksAndEvents.blocks, 100, (b, callback) => {
-        storage.blocks.add(b.block, b.meta, err => {
-          assertNoError(err);
-          callback();
-        });
-      }, done);
-    });
+
+    // NOTE: the events added here are referenced in the blocks.add test
     it(`events.add events`, function(done) {
       this.timeout(320000);
       console.log(`Adding ${blocksAndEvents.events.length} events.`);
@@ -63,6 +56,18 @@ describe('Performance tests', () => {
         assertNoError(err);
         done();
       });
+    });
+
+    // NOTE: the events referenced in the blocks are stored in events.add
+    it(`blocks.add ${blockNum} blocks`, function(done) {
+      this.timeout(320000);
+      async.eachLimit(
+        blocksAndEvents.blocks, 100, ({block, meta}, callback) => {
+          storage.blocks.add({block, meta}, err => {
+            assertNoError(err);
+            callback();
+          });
+        }, done);
     });
     it(`add ${outstandingEventNum} events without consensus`, function(done) {
       this.timeout(320000);

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -79,8 +79,8 @@ api.createEvent = ({eventTemplate, eventNum, consensus = true}, callback) => {
   async.timesLimit(eventNum, 100, (i, callback) => {
     const event = bedrock.util.clone(eventTemplate);
     event.id = `https://example.com/events/${uuid()}`;
-    api.testHasher(event, (err, result) => {
-      const meta = {eventHash: result};
+    api.testHasher(event, (err, eventHash) => {
+      const meta = {eventHash};
       if(consensus) {
         meta.consensus = true;
         meta.consensusDate = Date.now();

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -60,8 +60,7 @@ api.createBlocks = (
           }
           meta.blockHash = result;
           // block is stored with the eventHashes
-          block.event = results.events.map(
-            e => database.hash(e.meta.eventHash));
+          block.event = results.events.map(e => e.meta.eventHash);
           blocks.push({block, meta});
           callback();
         });

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -60,7 +60,8 @@ api.createBlocks = (
           }
           meta.blockHash = result;
           // block is stored with the eventHashes
-          block.event = results.events.map(e => e.meta.eventHash);
+          block.event = results.events.map(
+            e => database.hash(e.meta.eventHash));
           blocks.push({block, meta});
           callback();
         });

--- a/test/package.json
+++ b/test/package.json
@@ -30,7 +30,7 @@
     "bedrock-jobs": "^2.0.3",
     "bedrock-ledger-context": "digitalbazaar/bedrock-ledger-context#master",
     "bedrock-ledger-node": "digitalbazaar/bedrock-ledger-node#master",
-    "bedrock-mongodb": "^4.0.0",
+    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#5.x",
     "bedrock-permission": "^2.3.2",
     "bedrock-test": "^1.2.0",
     "grunt": "^1.0.1",


### PR DESCRIPTION
- [x] Blocks no longer contain references to events
- [x] Events contain references to blockHeight
- [ ] Store operations separately from events using the same pattern as blocks/events 

Does order of events in the block need to be preserved?