### PR TITLE
Implement _finishIncompleteBlock.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,7 +185,7 @@ api.add = (meta, options, callback) => {
       }, {
         collection: results.generateUuid.blockCollection,
         fields: {'meta._status': 1},
-        options: {sparse: false, unique: false, background: false}
+        options: {unique: false, background: false}
       }, {
         collection: results.generateUuid.operationCollection,
         fields: {'meta.eventHash': 1, 'meta.eventOrder': 1},

--- a/lib/index.js
+++ b/lib/index.js
@@ -183,6 +183,10 @@ api.add = (meta, options, callback) => {
         fields: {'meta.consensusDate': 1},
         options: {unique: false, background: false}
       }, {
+        collection: results.generateUuid.blockCollection,
+        fields: {'meta._status': 1},
+        options: {sparse: false, unique: false, background: false}
+      }, {
         collection: results.generateUuid.operationCollection,
         fields: {'meta.eventHash': 1, 'meta.eventOrder': 1},
         options: {unique: true, background: false}

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -24,6 +24,10 @@ module.exports = class LedgerBlockStorage {
     this.eventCollection = eventCollection;
     // event storage API
     this.eventStorage = eventStorage;
+    this.constants = {
+      STARTED: 0,
+      HASHES_STORED: 1,
+    };
   }
 
   /**
@@ -51,41 +55,46 @@ module.exports = class LedgerBlockStorage {
       throw new TypeError('`meta.blockHash` is required.');
     }
     const {blockHeight, event} = block;
+    const {blockHash} = meta;
     // drop `event` from the block without mutating or cloning
     const _block = _.pickBy(block, (v, k) => k !== 'event');
-    async.auto({
-      insert: callback => {
-        // insert the block
-        const now = Date.now();
-        const record = {
-          block: _block,
-          blockHash: database.hash(meta.blockHash),
-          id: database.hash(block.id),
-          meta: _.defaults(meta, {
-            created: now,
-            updated: now
-          }),
-        };
+    // do not mutate meta
+    const _meta = bedrock.util.clone(meta);
+    const now = Date.now();
+    _.defaults(_meta, {created: now, updated: now});
+    _meta._status = this.constants.STARTED;
 
-        logger.debug(`adding block: ${meta.blockHash}`);
-        this.collection.insert(record, database.writeOptions, (err, result) => {
+    const blockRecord = {
+      block: _block,
+      blockHash: database.hash(meta.blockHash),
+      id: database.hash(block.id),
+      meta: _meta,
+    };
+
+    const hashCollectionName =
+      `${this.collection.s.name}-event-hashes-${blockHeight}`;
+
+    logger.debug(`adding block: ${meta.blockHash}`);
+    async.auto({
+      finish: callback => this._finishIncompleteBlock(callback),
+      insert: ['finish', (results, callback) => this.collection.insert(
+        blockRecord, database.writeOptions, (err, result) => {
           if(err) {
             return callback(err);
           }
           callback(null, result.ops[0]);
-        });
-      },
-      update: ['insert', (results, callback) => {
-        async.timesLimit(event.length, 100, (i, callback) => {
-          const query = {eventHash: database.hash(event[i])};
-          this.eventCollection.update(
-            query, {$set: {
-              'meta.blockHeight': blockHeight,
-              'meta.blockOrder': i
-            }},
-            database.writeOptions, callback);
-        }, callback);
-      }]
+        })],
+      recordEventHashes: ['insert', (results, callback) =>
+        this._recordEventHashes({event, hashCollectionName}, callback)],
+      updateBlockStatus: ['recordEventHashes', (results, callback) => {
+        const patch = [{
+          op: 'set',
+          changes: {meta: {_status: this.constants.HASHES_STORED}}
+        }];
+        this.update({blockHash, patch}, callback);
+      }],
+      stage2: ['updateBlockStatus', (results, callback) => this._addStage2(
+        {blockHash, blockHeight, hashCollectionName}, callback)]
     }, (err, results) => {
       if(err) {
         if(database.isDuplicateError(err)) {
@@ -641,6 +650,47 @@ module.exports = class LedgerBlockStorage {
     }, callback);
   }
 
+  // TODO: needs a better name
+  _addStage2({blockHash, blockHeight, hashCollectionName}, callback) {
+    async.auto({
+      assignEvents: callback => this._assignEventsToBlock(
+        {blockHeight, hashCollectionName}, callback),
+      updateBlock: ['assignEvents', (results, callback) => {
+        const patch = [{
+          op: 'unset',
+          changes: {meta: {_status: 1}}
+        }];
+        this.update({blockHash, patch}, callback);
+      }],
+      dropHashCollection: ['updateBlock', (results, callback) => {
+        const collection = database.collections[hashCollectionName];
+        collection.drop(callback);
+      }]
+    }, callback);
+  }
+
+  _assignEventsToBlock({blockHeight, hashCollectionName}, callback) {
+    const q = async.queue((record, callback) => {
+      // build update
+      const {eventHash, blockOrder} = record;
+      const patch = [{
+        op: 'set',
+        changes: {meta: {blockHeight, blockOrder}}
+      }];
+      this.eventStorage.update({eventHash, patch}, callback);
+    }, 100); // TODO: make this concurrency limit configurable?
+
+    q.drain = callback;
+    q.error = err => {
+      q.kill();
+      callback(err);
+    };
+
+    const collection = database.collections[hashCollectionName];
+    const projection = {_id: 0, blockOrder: 1, eventHash: 1};
+    collection.find({}, projection).forEach(r => q.push(r));
+  }
+
   // FIXME: this might be accomplished with aggregate query
   _expandEvents(block, callback) {
     block.event = [];
@@ -663,5 +713,66 @@ module.exports = class LedgerBlockStorage {
           block.event.push(event);
         }, callback);
       });
+  }
+
+  _finishIncompleteBlock(callback) {
+    async.auto({
+      find: callback => this.collection.findOne(
+        {'meta._status': {$exists: true}}, (err, result) => {
+          if(err) {
+            return callback(err);
+          }
+          if(!result) {
+            return callback(new BedrockError(
+              'No failed blocks found.', 'NotFoundError'));
+          }
+          const {_status} = result.meta;
+          if(_status === this.constants.STARTED) {
+            // failure occurred before event hashes were recorded
+            return callback(new BedrockError(
+              'An unrecoverable block was found.', 'InvalidStateError',
+              result));
+          }
+          // status must be HASHES_STORED, so events need to be updated
+          callback(null, result);
+        }),
+      resume: ['find', (results, callback) => {
+        const {blockHash} = results.find.meta;
+        const {blockHeight} = results.find.block;
+        const hashCollectionName =
+          `${this.collection.s.name}-event-hashes-${blockHeight}`;
+        this._addStage2({blockHash, blockHeight, hashCollectionName}, callback);
+      }]
+    }, err => {
+      if(err && err.name === 'NotFoundError') {
+        // no incomplete blocks found, proceed without error
+        return callback();
+      }
+      if(err) {
+        return callback(err);
+      }
+      callback();
+    });
+  }
+
+  // create a temporary collection to hold list of eventHashes in the block
+  // create one document per hash rather than storing as an array because
+  // an array could exceed max document size
+  _recordEventHashes({event, hashCollectionName}, callback) {
+    // `blockOrder` is established here, it doesn't matter what order these
+    // records are processed in subsequent stages, and there is no need for
+    // an index on the temporary collection
+    const eventRecords = event.map((eventHash, blockOrder) => ({
+      blockOrder, eventHash
+    }));
+    async.auto({
+      open: callback => database.openCollections(
+        [hashCollectionName], callback),
+      insert: ['open', (results, callback) => {
+        const collection = database.collections[hashCollectionName];
+        const options = _.defaults({ordered: false}, database.writeOptions);
+        collection.insertMany(eventRecords, options, callback);
+      }]
+    }, err => callback(err));
   }
 };

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -76,7 +76,8 @@ module.exports = class LedgerBlockStorage {
 
     logger.debug(`adding block: ${meta.blockHash}`);
     async.auto({
-      finish: callback => this._finishIncompleteBlock(callback),
+      finish: callback => this._finishIncompleteBlock(
+        {hashCollectionName}, callback),
       insert: ['finish', (results, callback) => this.collection.insert(
         blockRecord, database.writeOptions, (err, result) => {
           if(err) {
@@ -715,7 +716,7 @@ module.exports = class LedgerBlockStorage {
       });
   }
 
-  _finishIncompleteBlock(callback) {
+  _finishIncompleteBlock({hashCollectionName}, callback) {
     async.auto({
       find: callback => this.collection.findOne(
         {'meta._status': {$exists: true}}, (err, result) => {
@@ -739,8 +740,6 @@ module.exports = class LedgerBlockStorage {
       resume: ['find', (results, callback) => {
         const {blockHash} = results.find.meta;
         const {blockHeight} = results.find.block;
-        const hashCollectionName =
-          `${this.collection.s.name}-event-hashes-${blockHeight}`;
         this._addStage2({blockHash, blockHeight, hashCollectionName}, callback);
       }]
     }, err => {


### PR DESCRIPTION
Once this gets ironed out, the same technique will be applied to events/operations.

Once this is finalized need to catch some specific errors at the consensus level.  Still not sure what our recourse is if the eventHashes fail to be saved, but I reckon we have to address that at a higher level.  Maybe it's just a matter of wiping the failed block and starting over.

Based on our current implementation with Continuity, I guess there is some application for a block that does *not* have consensus, and therefore it is left to the consensus algorithm to mark the block's `meta.consensus` etc.  Is my understanding correct?