### PR TITLE
Implement `block.add` event emitter.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,14 +4,14 @@
 'use strict';
 
 const _ = require('lodash');
+const assert = require('assert-plus');
 const async = require('async');
 const bedrock = require('bedrock');
 const brLedgerNode = require('bedrock-ledger-node');
 const database = require('bedrock-mongodb');
 const logger = require('./logger');
 const uuid = require('uuid/v4');
-// const util = require('util');
-const BedrockError = bedrock.util.BedrockError;
+const {BedrockError} = bedrock.util;
 const LedgerBlockStorage = require('./ledgerBlockStorage');
 const LedgerEventStorage = require('./ledgerEventStorage');
 const LedgerOperationStorage = require('./ledgerOperationStorage');
@@ -21,8 +21,6 @@ require('./config');
 // module API
 const api = {};
 module.exports = api;
-
-// const logger = bedrock.loggers.get('app');
 
 bedrock.events.on('bedrock-mongodb.ready', callback => async.auto({
   openCollections: callback =>
@@ -68,11 +66,11 @@ bedrock.events.on('bedrock.start', () => {
  *          storage the storage to use for the purposes of accessing and
  *            modifying the ledger.
  */
-api.add = (meta, options, callback) => {
-  // ensure ledger ID is specified
-  if(!(options.ledgerId && typeof options.ledgerId === 'string')) {
-    throw new TypeError('"options.ledgerId" must be a string.');
-  }
+api.add = (meta = {}, options = {}, callback) => {
+  assert.object(meta, 'meta');
+  assert.object(options, 'options');
+  assert.string(options.ledgerId, 'options.ledgerId');
+  assert.string(options.ledgerNodeId, 'options.ledgerNodeId');
 
   async.auto({
     generateUuid: callback => {
@@ -95,6 +93,7 @@ api.add = (meta, options, callback) => {
           eventCollection: results.generateUuid.eventCollection,
           id: 'urn:uuid:' + results.generateUuid.uuid,
           ledger: options.ledgerId,
+          ledgerNode: options.ledgerNodeId,
           operationCollection: results.generateUuid.operationCollection
         },
         meta: _.defaults(meta, {
@@ -195,6 +194,7 @@ api.add = (meta, options, callback) => {
           database.collections[results.generateUuid.blockCollection],
         eventCollection:
           database.collections[results.generateUuid.eventCollection],
+        ledgerNodeId: options.ledgerNodeId,
         operationCollection:
           database.collections[results.generateUuid.operationCollection],
         storageId: 'urn:uuid:' + results.generateUuid.uuid,
@@ -250,13 +250,14 @@ api.get = (storageId, options, callback) => {
       return callback(err);
     }
     const lsOptions = {
-      storageId: results.find.ledger.id,
       blockCollection:
         database.collections[results.find.ledger.blockCollection],
       eventCollection:
         database.collections[results.find.ledger.eventCollection],
+      ledgerNodeId: results.find.ledger.ledgerNode,
       operationCollection:
         database.collections[results.find.ledger.operationCollection],
+      storageId: results.find.ledger.id,
     };
     const ledgerStorage = new LedgerStorage(lsOptions);
     callback(null, ledgerStorage);

--- a/lib/ledgerBlockStorage.js
+++ b/lib/ledgerBlockStorage.js
@@ -17,13 +17,14 @@ const {BedrockError} = bedrock.util;
  * particular ledger.
  */
 module.exports = class LedgerBlockStorage {
-  constructor({blockCollection, eventCollection, eventStorage}) {
+  constructor({blockCollection, eventCollection, eventStorage, ledgerNodeId}) {
     // assign the collection used for block storage
     this.collection = blockCollection;
     // assign the collection used for events storage
     this.eventCollection = eventCollection;
     // event storage API
     this.eventStorage = eventStorage;
+    this.ledgerNodeId = ledgerNodeId;
   }
 
   /**
@@ -31,8 +32,10 @@ module.exports = class LedgerBlockStorage {
    * block.
    *
    * @param block - the block to create in the ledger.
-   *   blockHeight - the height of the block
-   *   event - an array of events associated with the block
+   *   blockHeight - the height of the block.
+   *   event - an array of events associated with the block.
+   * @param emit - when true (default), a bedrock event is emitted to inform
+   *  listeners that a block has been added.
    * @param meta - the metadata associated with the block.
    *   blockHash - the hash value of the block.
    * @param callback(err) - the callback to call when finished.
@@ -41,7 +44,7 @@ module.exports = class LedgerBlockStorage {
    *     block - the block that was committed to storage.
    *     meta - the metadata that was committed to storage.
    */
-  add({block, meta}, callback) {
+  add({block, emit = true, meta}, callback) {
     // check block
     if(!(block && Number.isInteger(block.blockHeight) && block.event)) {
       throw new TypeError(
@@ -98,6 +101,14 @@ module.exports = class LedgerBlockStorage {
           callback(null, result.ops[0]);
         });
       }],
+      emit: ['insert', (results, callback) => {
+        if(!emit) {
+          return callback();
+        }
+        bedrock.events.emit('bedrock-ledger-storage.block.add', {
+          blockHeight, ledgerNodeId: this.ledgerNodeId
+        }, callback);
+      }]
     }, (err, results) => {
       if(err) {
         if(database.isDuplicateError(err)) {

--- a/lib/ledgerEventStorage.js
+++ b/lib/ledgerEventStorage.js
@@ -22,10 +22,11 @@ const {BedrockError} = bedrock.util;
  * with a particular ledger.
  */
 module.exports = class LedgerEventStorage {
-  constructor({eventCollection, operationStorage}) {
+  constructor({eventCollection, ledgerNodeId, operationStorage}) {
     // assign the collection used for event storage
     this.collection = eventCollection;
     this.operationStorage = operationStorage;
+    this.ledgerNodeId = ledgerNodeId;
   }
 
   /**

--- a/lib/ledgerOperationStorage.js
+++ b/lib/ledgerOperationStorage.js
@@ -18,9 +18,10 @@ const {BedrockError} = bedrock.util;
  * a particular event.
  */
 module.exports = class LedgerOperationStorage {
-  constructor({eventCollection, operationCollection}) {
+  constructor({eventCollection, ledgerNodeId, operationCollection}) {
     this.collection = operationCollection;
     this.eventCollectionName = eventCollection.s.name;
+    this.ledgerNodeId = ledgerNodeId;
   }
 
   addMany({ignoreDuplicate = true, operations}, callback) {

--- a/test/mocha/10-ledger-api.js
+++ b/test/mocha/10-ledger-api.js
@@ -19,7 +19,8 @@ describe('Ledger Storage API', () => {
   it('should add a ledger', done => {
     const meta = {};
     const options = {
-      ledgerId: 'did:v1:' + uuid()
+      ledgerId: `did:v1:${uuid()}`,
+      ledgerNodeId: `urn:uuid:${uuid()}`,
     };
 
     async.auto({
@@ -47,7 +48,8 @@ describe('Ledger Storage API', () => {
   it('should get ledger', done => {
     const meta = {};
     const options = {
-      ledgerId: 'did:v1:' + uuid()
+      ledgerId: `did:v1:${uuid()}`,
+      ledgerNodeId: `urn:uuid:${uuid()}`,
     };
 
     async.auto({
@@ -83,7 +85,7 @@ describe('Ledger Storage API', () => {
     const storageIds = [];
     async.every(ledgerIds, (ledgerId, callback) => {
       const meta = {};
-      const options = {ledgerId};
+      const options = {ledgerId, ledgerNodeId: `urn:uuid:${uuid()}`};
       blsMongodb.add(meta, options, (err, storage) => {
         assertNoError(err);
         storageIds.push(storage.id);
@@ -115,7 +117,8 @@ describe('Ledger Storage API', () => {
     const meta = {};
     const options = {
       ledgerId: 'did:v1:' + uuid(),
-      owner: testOwner
+      ledgerNodeId: `urn:uuid:${uuid()}`,
+      owner: testOwner,
     };
 
     async.auto({

--- a/test/mocha/20-block-api.js
+++ b/test/mocha/20-block-api.js
@@ -12,7 +12,8 @@ const helpers = require('./helpers');
 const mockData = require('./mock.data');
 const uuid = require('uuid/v4');
 
-const exampleLedgerId = 'did:v1:' + uuid();
+const exampleLedgerId = `did:v1:${uuid()}`;
+const exampleLedgerNodeId = `urn:uuid:${uuid()}`;
 const configEventTemplate = bedrock.util.clone(mockData.events.config);
 configEventTemplate.ledger = exampleLedgerId;
 
@@ -29,7 +30,9 @@ describe('Block Storage API', () => {
   before(done => {
     const block = bedrock.util.clone(configBlockTemplate);
     const meta = {};
-    const options = {ledgerId: exampleLedgerId};
+    const options = {
+      ledgerId: exampleLedgerId, ledgerNodeId: exampleLedgerNodeId
+    };
 
     async.auto({
       initStorage: callback => blsMongodb.add(meta, options, (err, storage) => {

--- a/test/mocha/30-event-api.js
+++ b/test/mocha/30-event-api.js
@@ -12,7 +12,8 @@ const helpers = require('./helpers');
 const mockData = require('./mock.data');
 const uuid = require('uuid/v4');
 
-const exampleLedgerId = 'did:v1:' + uuid();
+const exampleLedgerId = `did:v1:${uuid()}`;
+const exampleLedgerNodeId = `urn:uuid:${uuid()}`;
 const configEventTemplate = bedrock.util.clone(mockData.events.config);
 configEventTemplate.ledger = exampleLedgerId;
 
@@ -26,7 +27,10 @@ describe('Event Storage API', () => {
   before(done => {
     const block = bedrock.util.clone(configBlockTemplate);
     const meta = {};
-    const options = {ledgerId: exampleLedgerId};
+    const options = {
+      ledgerId: exampleLedgerId,
+      ledgerNodeId: exampleLedgerNodeId,
+    };
 
     async.auto({
       initStorage: callback => blsMongodb.add(meta, options, (err, storage) => {
@@ -369,7 +373,10 @@ describe('Event Storage API', () => {
     });
     it('returns NotFoundError when there is no configuration', done => {
       const meta = {};
-      const options = {ledgerId: `urn:${uuid()}`};
+      const options = {
+        ledgerId: `urn:${uuid()}`,
+        ledgerNodeId: `urn:uuid:${uuid()}`
+      };
       async.auto({
         ledgerStorage: callback => blsMongodb.add(meta, options, callback),
         latest: ['ledgerStorage', (results, callback) => {
@@ -418,7 +425,10 @@ describe('Event Storage API', () => {
     });
     it('returns NotFoundError when there is no configuration', done => {
       const meta = {};
-      const options = {ledgerId: `urn:${uuid()}`};
+      const options = {
+        ledgerId: `urn:${uuid()}`,
+        ledgerNodeId: `urn:uuid:${uuid()}`
+      };
       async.auto({
         ledgerStorage: callback => blsMongodb.add(meta, options, callback),
         latest: ['ledgerStorage', (results, callback) => {

--- a/test/mocha/35-operation-api.js
+++ b/test/mocha/35-operation-api.js
@@ -12,7 +12,8 @@ const helpers = require('./helpers');
 const mockData = require('./mock.data');
 const uuid = require('uuid/v4');
 
-const exampleLedgerId = 'did:v1:' + uuid();
+const exampleLedgerId = `did:v1:${uuid()}`;
+const exampleLedgerNodeId = `urn:uuid:${uuid()}`;
 const configEventTemplate = bedrock.util.clone(mockData.events.config);
 configEventTemplate.ledger = exampleLedgerId;
 
@@ -25,7 +26,9 @@ describe('Operation Storage API', () => {
   before(done => {
     const block = bedrock.util.clone(configBlockTemplate);
     const meta = {};
-    const options = {ledgerId: exampleLedgerId};
+    const options = {
+      ledgerId: exampleLedgerId, ledgerNodeId: exampleLedgerNodeId
+    };
 
     async.auto({
       initStorage: callback => blsMongodb.add(meta, options, (err, storage) => {

--- a/test/mocha/50-driver-api.js
+++ b/test/mocha/50-driver-api.js
@@ -10,7 +10,8 @@ const helpers = require('./helpers');
 const mockData = require('./mock.data');
 const uuid = require('uuid/v4');
 
-const exampleLedgerId = 'did:v1:' + uuid();
+const exampleLedgerId = `did:v1:${uuid()}`;
+const exampleLedgerNodeId = `urn:uuid:${uuid()}`;
 const configEventTemplate = bedrock.util.clone(mockData.events.config);
 configEventTemplate.ledger = exampleLedgerId;
 
@@ -24,8 +25,9 @@ describe('Ledger Storage Driver API', () => {
   before(done => {
     const block = bedrock.util.clone(configBlockTemplate);
     const meta = {};
-    const options = {ledgerId: exampleLedgerId};
-
+    const options = {
+      ledgerId: exampleLedgerId, ledgerNodeId: exampleLedgerNodeId
+    };
     async.auto({
       initStorage: callback => blsMongodb.add(
         meta, options, (err, storage) => {

--- a/test/mocha/60-performance.js
+++ b/test/mocha/60-performance.js
@@ -10,7 +10,8 @@ const helpers = require('./helpers');
 const mockData = require('./mock.data');
 const uuid = require('uuid/v4');
 
-const exampleLedgerId = 'did:v1:' + uuid();
+const exampleLedgerId = `did:v1:${uuid()}`;
+const exampleLedgerNodeId = `urn:uuid:${uuid()}`;
 const configEventTemplate = bedrock.util.clone(mockData.events.config);
 configEventTemplate.ledger = exampleLedgerId;
 
@@ -22,8 +23,9 @@ describe('Performance tests', () => {
   before(done => {
     const block = bedrock.util.clone(configBlockTemplate);
     const meta = {};
-    const options = {ledgerId: exampleLedgerId};
-
+    const options = {
+      ledgerId: exampleLedgerId, ledgerNodeId: exampleLedgerNodeId
+    };
     async.auto({
       initStorage: callback => blsMongodb.add(meta, options, (err, storage) => {
         ledgerStorage = storage;

--- a/test/package.json
+++ b/test/package.json
@@ -29,7 +29,7 @@
     "bedrock-identity": "^4.6.0",
     "bedrock-jobs": "^2.0.3",
     "bedrock-ledger-context": "^1.0.0",
-    "bedrock-ledger-node": "digitalbazaar/bedrock-ledger-node#master",
+    "bedrock-ledger-node": "digitalbazaar/bedrock-ledger-node#storageLedgerNodeId",
     "bedrock-ledger-storage-mongodb": "file:..",
     "bedrock-mongodb": "^5.0.0",
     "bedrock-permission": "^2.3.2",


### PR DESCRIPTION
`emit` is optional in support of consensus algorithms that might add blocks before they are finalized.  

Depends on: https://github.com/digitalbazaar/bedrock-ledger-node/pull/22