### PR TITLE
various fixes to make JSDoc pretty

### DIFF
--- a/lib/LedgerBlockStorage.js
+++ b/lib/LedgerBlockStorage.js
@@ -16,8 +16,9 @@ const {BedrockError} = bedrock.util;
 /**
  * The blocks API is used to perform operations on blocks associated with a
  * particular ledger.
+ * @memberof module:bedrock-ledger-storage-mongodb
  */
-module.exports = class LedgerBlockStorage {
+class LedgerBlockStorage {
   constructor({blockCollection, eventCollection, eventStorage, ledgerNodeId}) {
     // assign the collection used for block storage
     this.collection = blockCollection;
@@ -698,4 +699,6 @@ module.exports = class LedgerBlockStorage {
         }, callback);
       });
   }
-};
+}
+
+module.exports = LedgerBlockStorage;

--- a/lib/LedgerEventStorage.js
+++ b/lib/LedgerEventStorage.js
@@ -20,8 +20,9 @@ const {BedrockError} = bedrock.util;
 /**
  * The events API is used to perform operations on events associated
  * with a particular ledger.
+ * @memberof module:bedrock-ledger-storage-mongodb
  */
-module.exports = class LedgerEventStorage {
+class LedgerEventStorage {
   constructor({eventCollection, ledgerNodeId, operationStorage}) {
     // assign the collection used for event storage
     this.collection = eventCollection;
@@ -512,4 +513,6 @@ module.exports = class LedgerEventStorage {
       }]
     }, err => callback(err));
   }
-};
+}
+
+module.exports = LedgerEventStorage;

--- a/lib/LedgerOperationStorage.js
+++ b/lib/LedgerOperationStorage.js
@@ -15,8 +15,9 @@ const {BedrockError} = bedrock.util;
 /**
  * The operation API is used to perform operations on operations associated with
  * a particular event.
+ * @memberof module:bedrock-ledger-storage-mongodb
  */
-module.exports = class LedgerOperationStorage {
+class LedgerOperationStorage {
   constructor({eventCollection, ledgerNodeId, operationCollection}) {
     this.collection = operationCollection;
     this.eventCollection = eventCollection;
@@ -129,4 +130,6 @@ module.exports = class LedgerOperationStorage {
     this.collection.find(query).count((err, result) =>
       err ? callback(err) : callback(null, totalHashes === result));
   }
-};
+}
+
+module.exports = LedgerOperationStorage;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright (c) 2016-2018 Digital Bazaar, Inc. All rights reserved.
  */
+/** @module bedrock-ledger-storage-mongodb */
 'use strict';
 
 const _ = require('lodash');


### PR DESCRIPTION
There are two fixes here:

1. Using `module.exports` and creating a class on the same line causes JSDoc to define all the class members as `exports` rather than a class. This is intentional on JSDoc's part, since it is treating the `module.exports` as a definition of a CommonJS module. By moving the `module.exports` to the end of the file, it let's JSDoc focus on the class definition; although, it obfuscates the fact that the class is the only thing being exported.

2. I've sprinkled in `@module` and `@memberof module:` definitions. These are totally unnecessary right now, but will become necessary if trying to untangle classes across 100+ modules.