### PR TITLE
Derive collection names from ledgerNodeId.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,6 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     collection: 'ledger',
     fields: {'meta.deleted': 1},
     options: {unique: false, background: false}
-    // TODO: add index for `meta.consensus`
   }]);
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,6 @@ bedrock.events.on('bedrock.start', () => {
  * @return a Promise that resolves to a LedgerStorage instance.
  */
 api.add = callbackify(async (meta = {}, options = {}) => {
-  // TODO: break this function up into helpers for better readability
   assert.object(meta, 'meta');
   assert.object(options, 'options');
   assert.string(options.ledgerNodeId, 'options.ledgerNodeId');
@@ -74,15 +73,7 @@ api.add = callbackify(async (meta = {}, options = {}) => {
 
   // ensure that all the specified plugins are registered, no NotFoundError
   // and that the plugin type is valid
-  for(const pluginName of plugins) {
-    const p = brLedgerNode.use(pluginName);
-    if(p.type !== 'ledgerStoragePlugin') {
-      throw new BedrockError(
-        'The specified service plugin must have a type of ' +
-        '`ledgerStoragePlugin`.', 'InvalidAccessError',
-        {httpStatusCode: 400, public: true, pluginName});
-    }
-  }
+  _verifyPlugins(plugins);
 
   // generate UUIDs for the ledger storage
   const storageUuid = uuid();
@@ -119,93 +110,10 @@ api.add = callbackify(async (meta = {}, options = {}) => {
 
   // open the ledger collections
   await brOpenCollections(Object.values(record.ledger.collections));
+  await _createCoreIndexes(vars);
+  await _createPluginIndexes({plugins, ...vars});
 
-  // create indexes on block IDs, event IDs, and deleted flags
   const {blockCollection, eventCollection, operationCollection} = vars;
-  await brCreateIndexes([{
-    collection: eventCollection,
-    fields: {'meta.eventHash': 1},
-    options: {unique: true, background: false}
-  }, {
-    collection: eventCollection,
-    fields: {'meta.consensus': 1, 'event.type': 1, 'meta.blockHeight': 1},
-    options: {unique: false, background: false, name: 'eventIndex1'}
-  }, {
-    collection: eventCollection,
-    fields: {'event.type': 1, 'meta.created': 1},
-    options: {unique: false, background: false}
-  }, {
-    collection: eventCollection,
-    fields: {'event.type': 1, 'meta.consensusDate': 1},
-    options: {unique: false, background: false}
-  }, {
-    collection: eventCollection,
-    fields: {'meta.blockHeight': 1, 'meta.blockOrder': 1},
-    options: {sparse: true, unique: false, background: false}
-  }, {
-    collection: eventCollection,
-    fields: {'meta.deleted': 1, 'meta.eventHash': 1},
-    options: {unique: true, background: false}
-  }, {
-    collection: blockCollection,
-    fields: {id: 1},
-    options: {unique: true, background: false}
-  }, {
-    collection: blockCollection,
-    fields: {'block.blockHeight': 1},
-    options: {unique: false, background: false}
-  }, {
-    collection: blockCollection,
-    fields: {'block.type': 1, 'block.blockHeight': 1},
-    options: {unique: false, background: false}
-  }, {
-    collection: blockCollection,
-    fields: {'meta.blockHash': 1},
-    options: {unique: true, background: false}
-  }, {
-    collection: blockCollection,
-    fields: {'meta.deleted': 1},
-    options: {unique: false, background: false}
-  }, {
-    collection: blockCollection,
-    fields: {'meta.consensus': 1, 'block.previousBlockHash': 1},
-    options: {unique: true, background: false}
-  }, {
-    collection: blockCollection,
-    fields: {'meta.consensus': 1},
-    options: {unique: false, background: false}
-  }, {
-    collection: blockCollection,
-    fields: {'meta.consensusDate': 1},
-    options: {unique: false, background: false}
-  }, {
-    collection: operationCollection,
-    fields: {
-      'meta.eventHash': 1, 'meta.eventOrder': 1, 'meta.operationHash': 1,
-      'meta.deleted': 1,
-    },
-    options: {unique: true, background: false, name: 'operationIndex1'}
-  }, {
-    collection: operationCollection,
-    fields: {'recordId': 1},
-    options: {unique: false, background: false, name: 'operationIndex2'}
-  }]);
-
-  // storage plugins add indexes to collections by providing an
-  // `expandIndexes` method
-  if(plugins.length > 0) {
-    const options = {
-      createIndexes: brCreateIndexes,
-      collections: {blockCollection, eventCollection, operationCollection}
-    };
-    for(const pluginName of plugins) {
-      const {api: pluginApi} = brLedgerNode.use(pluginName);
-      if(pluginApi.expandIndexes) {
-        await pluginApi.expandIndexes(options);
-      }
-    }
-  }
-
   const lsOptions = {
     blockCollection: database.collections[blockCollection],
     eventCollection: database.collections[eventCollection],
@@ -340,6 +248,97 @@ api.getLedgerIterator = callbackify(async (options = {}) => {
   return iterator;
 });
 
+// create indexes on block IDs, event IDs, and deleted flags
+async function _createCoreIndexes(
+  {blockCollection, eventCollection, operationCollection}) {
+  await brCreateIndexes([{
+    collection: eventCollection,
+    fields: {'meta.eventHash': 1},
+    options: {unique: true, background: false}
+  }, {
+    collection: eventCollection,
+    fields: {'meta.consensus': 1, 'event.type': 1, 'meta.blockHeight': 1},
+    options: {unique: false, background: false, name: 'eventIndex1'}
+  }, {
+    collection: eventCollection,
+    fields: {'event.type': 1, 'meta.created': 1},
+    options: {unique: false, background: false}
+  }, {
+    collection: eventCollection,
+    fields: {'event.type': 1, 'meta.consensusDate': 1},
+    options: {unique: false, background: false}
+  }, {
+    collection: eventCollection,
+    fields: {'meta.blockHeight': 1, 'meta.blockOrder': 1},
+    options: {sparse: true, unique: false, background: false}
+  }, {
+    collection: eventCollection,
+    fields: {'meta.deleted': 1, 'meta.eventHash': 1},
+    options: {unique: true, background: false}
+  }, {
+    collection: blockCollection,
+    fields: {id: 1},
+    options: {unique: true, background: false}
+  }, {
+    collection: blockCollection,
+    fields: {'block.blockHeight': 1},
+    options: {unique: false, background: false}
+  }, {
+    collection: blockCollection,
+    fields: {'block.type': 1, 'block.blockHeight': 1},
+    options: {unique: false, background: false}
+  }, {
+    collection: blockCollection,
+    fields: {'meta.blockHash': 1},
+    options: {unique: true, background: false}
+  }, {
+    collection: blockCollection,
+    fields: {'meta.deleted': 1},
+    options: {unique: false, background: false}
+  }, {
+    collection: blockCollection,
+    fields: {'meta.consensus': 1, 'block.previousBlockHash': 1},
+    options: {unique: true, background: false}
+  }, {
+    collection: blockCollection,
+    fields: {'meta.consensus': 1},
+    options: {unique: false, background: false}
+  }, {
+    collection: blockCollection,
+    fields: {'meta.consensusDate': 1},
+    options: {unique: false, background: false}
+  }, {
+    collection: operationCollection,
+    fields: {
+      'meta.eventHash': 1, 'meta.eventOrder': 1, 'meta.operationHash': 1,
+      'meta.deleted': 1,
+    },
+    options: {unique: true, background: false, name: 'operationIndex1'}
+  }, {
+    collection: operationCollection,
+    fields: {'recordId': 1},
+    options: {unique: false, background: false, name: 'operationIndex2'}
+  }]);
+}
+
+// storage plugins add indexes to collections by providing an
+// `expandIndexes` method
+async function _createPluginIndexes(
+  {blockCollection, eventCollection, operationCollection, plugins}) {
+  if(plugins.length > 0) {
+    const options = {
+      createIndexes: brCreateIndexes,
+      collections: {blockCollection, eventCollection, operationCollection}
+    };
+    for(const pluginName of plugins) {
+      const {api: pluginApi} = brLedgerNode.use(pluginName);
+      if(pluginApi.expandIndexes) {
+        await pluginApi.expandIndexes(options);
+      }
+    }
+  }
+}
+
 // NOTE: mutates `ledgerStorage`
 function _extendLedgerStorage({ledgerStorage, plugins}) {
   if(plugins.length === 0) {
@@ -363,4 +362,16 @@ function _extendLedgerStorage({ledgerStorage, plugins}) {
     });
   }
   return ledgerStorage;
+}
+
+function _verifyPlugins(plugins) {
+  for(const pluginName of plugins) {
+    const p = brLedgerNode.use(pluginName);
+    if(p.type !== 'ledgerStoragePlugin') {
+      throw new BedrockError(
+        'The specified service plugin must have a type of ' +
+        '`ledgerStoragePlugin`.', 'InvalidAccessError',
+        {httpStatusCode: 400, public: true, pluginName});
+    }
+  }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,10 +67,10 @@ api.add = callbackify(async (meta = {}, options = {}) => {
   // TODO: break this function up into helpers for better readability
   assert.object(meta, 'meta');
   assert.object(options, 'options');
-  assert.string(options.ledgerId, 'options.ledgerId');
   assert.string(options.ledgerNodeId, 'options.ledgerNodeId');
   assert.optionalArrayOfString(options.plugins, 'options.plugins');
   const plugins = options.plugins || [];
+  const {ledgerNodeId} = options;
 
   // ensure that all the specified plugins are registered, no NotFoundError
   // and that the plugin type is valid
@@ -85,25 +85,26 @@ api.add = callbackify(async (meta = {}, options = {}) => {
   }
 
   // generate UUIDs for the ledger storage
-  const ledgerUuid = uuid();
-  const uuids = {
-    ledger: ledgerUuid,
-    eventCollection: ledgerUuid + '-event',
-    blockCollection: ledgerUuid + '-block',
-    operationCollection: ledgerUuid + '-operation'
+  const storageUuid = uuid();
+  const vars = {
+    storageId: `urn:uuid:${storageUuid}`,
+    eventCollection: `${storageUuid}-event`,
+    blockCollection: `${storageUuid}-block`,
+    operationCollection: `${storageUuid}-operation`,
   };
 
   // insert the ledger
   const now = Date.now();
   const record = {
-    id: 'urn:uuid:' + uuids.ledger,
+    id: vars.storageId,
     ledger: {
-      blockCollection: uuids.blockCollection,
-      eventCollection: uuids.eventCollection,
-      id: 'urn:uuid:' + uuids.ledger,
-      ledger: options.ledgerId,
-      ledgerNode: options.ledgerNodeId,
-      operationCollection: uuids.operationCollection,
+      collections: {
+        block: vars.blockCollection,
+        event: vars.eventCollection,
+        operation: vars.operationCollection,
+      },
+      id: vars.storageId,
+      ledgerNode: ledgerNodeId,
       plugins,
     },
     meta: _.defaults(meta, {
@@ -112,20 +113,15 @@ api.add = callbackify(async (meta = {}, options = {}) => {
     })
   };
 
-  logger.debug('adding ledger: ' + options.ledgerId);
+  logger.debug('adding storage', {ledgerNodeId});
 
   await database.collections.ledger.insert(record, database.writeOptions);
 
   // open the ledger collections
-  const ledgerCollections = [
-    uuids.blockCollection,
-    uuids.eventCollection,
-    uuids.operationCollection
-  ];
-  await brOpenCollections(ledgerCollections);
+  await brOpenCollections(Object.values(record.ledger.collections));
 
   // create indexes on block IDs, event IDs, and deleted flags
-  const {blockCollection, eventCollection, operationCollection} = uuids;
+  const {blockCollection, eventCollection, operationCollection} = vars;
   await brCreateIndexes([{
     collection: eventCollection,
     fields: {'meta.eventHash': 1},
@@ -215,7 +211,7 @@ api.add = callbackify(async (meta = {}, options = {}) => {
     eventCollection: database.collections[eventCollection],
     ledgerNodeId: options.ledgerNodeId,
     operationCollection: database.collections[operationCollection],
-    storageId: 'urn:uuid:' + uuids.ledger
+    storageId: vars.storageId,
   };
   const ledgerStorage = new LedgerStorage(lsOptions);
 
@@ -248,18 +244,14 @@ api.get = callbackify(async (storageId, options = {}) => {
 
   // open the ledger collections
   const {ledger} = record;
-  const ledgerCollections = [
-    ledger.blockCollection,
-    ledger.eventCollection,
-    ledger.operationCollection
-  ];
-  await brOpenCollections(ledgerCollections);
+  const {collections} = ledger;
+  await brOpenCollections(Object.values(collections));
 
   const lsOptions = {
-    blockCollection: database.collections[ledger.blockCollection],
-    eventCollection: database.collections[ledger.eventCollection],
+    blockCollection: database.collections[collections.block],
+    eventCollection: database.collections[collections.event],
     ledgerNodeId: ledger.ledgerNode,
-    operationCollection: database.collections[ledger.operationCollection],
+    operationCollection: database.collections[collections.operation],
     storageId: ledger.id,
   };
   const ledgerStorage = new LedgerStorage(lsOptions);

--- a/test/mocha/10-ledger-api.js
+++ b/test/mocha/10-ledger-api.js
@@ -28,14 +28,34 @@ describe('Ledger Storage API', () => {
     should.exist(storage);
     should.exist(storage.blocks);
     should.exist(storage.events);
+    should.exist(storage.operations);
 
     // ensure the ledger was created in the database
     const query = {id: storage.id};
     const record = await database.collections.ledger.findOne(query);
     should.exist(record);
+    should.exist(record.id);
+    record.id.should.be.a('string');
     should.exist(record.ledger.id);
-    should.exist(record.ledger.eventCollection);
-    should.exist(record.ledger.blockCollection);
+    record.ledger.id.should.be.a('string');
+    should.exist(record.ledger.ledgerNode);
+    record.ledger.ledgerNode.should.be.a('string');
+    should.exist(record.ledger.collections);
+    const {collections} = record.ledger;
+    collections.should.be.an('object');
+    should.exist(collections.block);
+    collections.block.should.be.a('string');
+    should.exist(collections.event);
+    collections.event.should.be.a('string');
+    should.exist(collections.operation);
+    collections.operation.should.be.a('string');
+    should.exist(record.ledger.plugins);
+    record.ledger.plugins.should.be.an('array');
+    record.ledger.plugins.should.have.length(0);
+    should.exist(record.meta);
+    record.meta.should.be.an('object');
+    should.exist(record.meta.created);
+    should.exist(record.meta.updated);
   });
   it('should get ledger', async () => {
     const meta = {};

--- a/test/mocha/40-plugin.js
+++ b/test/mocha/40-plugin.js
@@ -13,13 +13,13 @@ const mockData = require('./mock.data');
 const mockPlugin = require('./mock.plugin');
 const uuid = require('uuid/v4');
 
-const exampleLedgerId = `did:v1:${uuid()}`;
-const exampleLedgerNodeId = `urn:uuid:${uuid()}`;
+const exampleLedgerId = () => `did:v1:${uuid()}`;
+const exampleLedgerNodeId = () => `urn:uuid:${uuid()}`;
 const configEventTemplate = bedrock.util.clone(mockData.events.config);
-configEventTemplate.ledger = exampleLedgerId;
+configEventTemplate.ledger = exampleLedgerId();
 
 const configBlockTemplate = bedrock.util.clone(mockData.configBlocks.alpha);
-configBlockTemplate.id = exampleLedgerId + '/blocks/1';
+configBlockTemplate.id = configEventTemplate.ledger + '/blocks/1';
 
 // register mock plugin
 brLedgerNode.use('mock', mockPlugin);
@@ -29,7 +29,7 @@ describe('Storage Plugin API', () => {
     it('classes are extended on storage add', done => {
       const meta = {};
       const options = {
-        ledgerId: exampleLedgerId, ledgerNodeId: exampleLedgerNodeId,
+        ledgerId: exampleLedgerId(), ledgerNodeId: exampleLedgerNodeId(),
         plugins: ['mock']
       };
       async.auto({
@@ -46,7 +46,7 @@ describe('Storage Plugin API', () => {
     it('classes are extended on storage get', done => {
       const meta = {};
       const options = {
-        ledgerId: exampleLedgerId, ledgerNodeId: exampleLedgerNodeId,
+        ledgerId: exampleLedgerId(), ledgerNodeId: exampleLedgerNodeId(),
         plugins: ['mock']
       };
       async.auto({
@@ -69,7 +69,7 @@ describe('Storage Plugin API', () => {
     it('plugin adds an index to the operations collection', done => {
       const meta = {};
       const options = {
-        ledgerId: exampleLedgerId, ledgerNodeId: exampleLedgerNodeId,
+        ledgerId: exampleLedgerId(), ledgerNodeId: exampleLedgerNodeId(),
         plugins: ['mock']
       };
       async.auto({
@@ -96,7 +96,7 @@ describe('Storage Plugin API', () => {
       const block = bedrock.util.clone(configBlockTemplate);
       const meta = {};
       const options = {
-        ledgerId: exampleLedgerId, ledgerNodeId: exampleLedgerNodeId,
+        ledgerId: exampleLedgerId(), ledgerNodeId: exampleLedgerNodeId(),
         plugins: ['mock']
       };
 


### PR DESCRIPTION
Fixes #10.

This assumes that `ledgerNodeId` will be a `urn:uuid:` which I think is a safe assumption.

As mentioned in the original issue, being able to determined the collection names from the ledgerNodeId will be very helpful in debugging.  It's the difference between logging `ledgerNode.id` (which is often already being logged) and `ledgerNode.storage.events.collections.s.name`.