### PR TITLE
Remove getAll API from blocks.

### DIFF
--- a/lib/LedgerBlockStorage.js
+++ b/lib/LedgerBlockStorage.js
@@ -42,7 +42,6 @@ class LedgerBlockStorage {
     this.getSummary = callbackify(this.getSummary.bind(this));
     this.getByHeight = callbackify(this.getByHeight.bind(this));
     this.getSummaryByHeight = callbackify(this.getSummaryByHeight.bind(this));
-    this.getAll = callbackify(this.getAll.bind(this));
     this.getGenesis = callbackify(this.getGenesis.bind(this));
     this.getLatest = callbackify(this.getLatest.bind(this));
     this.getLatestSummary = callbackify(this.getLatestSummary.bind(this));
@@ -289,62 +288,6 @@ class LedgerBlockStorage {
       block.eventHash = records.map(r => r.meta.eventHash);
     }
     return {block, meta: record.meta};
-  }
-
-  /**
-   * Gets all blocks matching a given blockId even if they have not
-   * achieved consensus.
-   *
-   * @param blockId - the identifier of the block(s) to fetch from the ledger.
-   *
-   * @return a Promise that resolves to an iterator for all of the
-   *   returned blocks.
-   */
-  async getAll(blockId) {
-    // find an existing block
-    const query = {
-      id: database.hash(blockId),
-      'meta.deleted': {
-        $exists: false
-      }
-    };
-    const cursor = await this.collection.find(query);
-
-    // check to see if there are any results
-    let hasNext = false;
-    try {
-      hasNext = await cursor.hasNext();
-    } catch(e) {}
-
-    // create a block iterator
-    const iterator = {
-      done: !hasNext
-    };
-    iterator.next = () => {
-      if(iterator.done) {
-        return {done: true};
-      }
-      const promise = cursor.next().then(record => {
-        // ensure iterator will have something to iterate over next
-        return cursor.hasNext().then(hasNext => {
-          iterator.done = !hasNext;
-          // TODO: expand events in block
-          return {
-            block: record.block,
-            meta: record.meta
-          };
-        });
-      }).catch(err => {
-        iterator.done = true;
-        throw err;
-      });
-      return {value: promise, done: iterator.done};
-    };
-    iterator[Symbol.iterator] = () => {
-      return iterator;
-    };
-
-    return iterator;
   }
 
   /**

--- a/test/mocha/20-block-api.js
+++ b/test/mocha/20-block-api.js
@@ -191,48 +191,6 @@ describe('Block Storage API', () => {
     });
   }); // end get API
 
-  describe('getAll API', () => {
-    it('should get all blocks with given ID', done => {
-      const blockTemplate = eventBlockTemplate;
-      const eventTemplate = mockData.events.alpha;
-      async.auto({
-        create: callback => helpers.createBlocks(
-          {blockTemplate, eventTemplate, opTemplate}, callback),
-        operations: ['create', (results, callback) => {
-          const {operations} = results.create;
-          ledgerStorage.operations.addMany({operations}, callback);
-        }],
-        event: ['operations', (results, callback) => ledgerStorage.events.add(
-          results.create.events[0], callback)],
-        block: ['event', (results, callback) => ledgerStorage.blocks.add(
-          results.create.blocks[0], callback)],
-        getAll: ['block', (results, callback) => {
-          const {id: blockId} = results.create.blocks[0].block;
-          ledgerStorage.blocks.getAll(blockId, (err, iterator) => {
-            assertNoError(err);
-            should.exist(iterator);
-
-            let blockCount = 0;
-            async.eachSeries(iterator, (promise, callback) => {
-              promise.then(result => {
-                should.exist(result.block);
-                should.exist(result.meta);
-                result.block.id.should.equal(blockId);
-                blockCount++;
-                callback();
-              }, callback);
-            }, err => {
-              assertNoError(err);
-              blockCount.should.equal(1);
-              callback();
-            });
-          });
-        }]
-      }, done);
-
-    });
-  }); // end getAll
-
   describe('update API', () => {
     it('should update block', done => {
       const blockTemplate = eventBlockTemplate;


### PR DESCRIPTION
Fixes #7.

It wasn't being used and doesn't seem useful.