### PR TITLE
Implement util.chunkDocuments.

### DIFF
--- a/lib/LedgerEventStorage.js
+++ b/lib/LedgerEventStorage.js
@@ -6,12 +6,12 @@
 'use strict';
 
 const _ = require('lodash');
+const _util = require('./util');
 const assert = require('assert-plus');
 const bedrock = require('bedrock');
 const database = require('bedrock-mongodb');
-const jsonld = bedrock.jsonld;
+const {jsonld, util: {callbackify, BedrockError}} = bedrock;
 const logger = require('./logger');
-const {callbackify, BedrockError} = bedrock.util;
 
 // this projection stage is used in multiple aggregate queries, it is used
 // to conditionally remove `event.operation` from `event` objects
@@ -147,19 +147,23 @@ class LedgerEventStorage {
   // TODO: add docs
   async addMany({events}) {
     const dupHashes = [];
-    // retry indefinitely on duplicate errors (duplicates will be removed
-    // from the `event` array so the rest of the events can be inserted)
-    while(events.length > 0) {
-      try {
-        await this.collection.insertMany(events, {ordered: true});
-        events = [];
-      } catch(e) {
-        if(!database.isDuplicateError(e)) {
-          throw e;
+
+    const chunks = _util.chunkDocuments(events);
+    for(let chunk of chunks) {
+      // retry indefinitely on duplicate errors (duplicates will be removed
+      // from the `chunk` array so the rest of the events can be inserted)
+      while(chunk.length > 0) {
+        try {
+          await this.collection.insertMany(chunk, {ordered: true});
+          chunk = [];
+        } catch(e) {
+          if(!database.isDuplicateError(e)) {
+            throw e;
+          }
+          // remove events up to the dup and retry
+          dupHashes.push(chunk[e.index].meta.eventHash);
+          chunk = chunk.slice(e.index + 1);
         }
-        // remove events up to the dup and retry
-        dupHashes.push(events[e.index].meta.eventHash);
-        events = events.slice(e.index + 1);
       }
     }
     return {dupHashes};

--- a/lib/LedgerOperationStorage.js
+++ b/lib/LedgerOperationStorage.js
@@ -6,11 +6,12 @@
 'use strict';
 
 const _ = require('lodash');
+const _util = require('./util');
 const assert = require('assert-plus');
 const bedrock = require('bedrock');
 const database = require('bedrock-mongodb');
 const logger = require('./logger');
-const {callbackify, BedrockError} = bedrock.util;
+const {util: {callbackify, BedrockError}} = bedrock;
 
 /**
  * The operation API is used to perform operations on operations associated with
@@ -40,14 +41,17 @@ class LedgerOperationStorage {
 
   // TODO: document
   async addMany({ignoreDuplicate = true, operations}) {
-    try {
-      await this.collection.insertMany(
-        operations, _.assign({}, database.writeOptions, {ordered: false}));
-    } catch(e) {
-      if(ignoreDuplicate && database.isDuplicateError(e)) {
-        return;
+    const chunks = _util.chunkDocuments(operations);
+    for(const chunk of chunks) {
+      try {
+        await this.collection.insertMany(
+          chunk, Object.assign({}, database.writeOptions, {ordered: false}));
+      } catch(e) {
+        if(ignoreDuplicate && database.isDuplicateError(e)) {
+          return;
+        }
+        throw e;
       }
-      throw e;
     }
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const BSON = require('bson');
+
+// max MongoDB document size leaving 5% for data structure overhead, see:
+// https://github.com/digitalbazaar/bedrock-ledger-storage-mongodb/issues/47
+const maxBatchSizeBytes = Math.round(1024 * 1024 * 16 * .95);
+
+exports.chunkDocuments = documents => {
+  const size = BSON.calculateObjectSize(documents);
+
+  if(size <= maxBatchSizeBytes) {
+    return [documents];
+  }
+
+  const chunks = [];
+  let chunk = [];
+  let chunkBytes = 0;
+  for(let i = 0; i < documents.length; ++i) {
+    const opBytes = BSON.calculateObjectSize(documents[i]);
+    if((chunkBytes + opBytes) <= maxBatchSizeBytes) {
+      chunk.push(documents[i]);
+      chunkBytes += opBytes;
+    } else {
+      // start a new chunk
+      chunks.push(chunk);
+      chunk = [documents[i]];
+      chunkBytes = opBytes;
+    }
+    // if this is the last document, push the chunk
+    if(i === documents.length - 1) {
+      chunks.push(chunk);
+    }
+  }
+
+  return chunks;
+};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-ledger-storage-mongodb/",
   "dependencies": {
     "assert-plus": "^1.0.0",
+    "bson": "^4.0.2",
     "fast-json-patch": "^2.0.6",
+    "lodash": "^4.17.11",
     "uuid": "^3.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
The MongoDB `insertMany` API has been used here without first ensuring that the sum total of all the documents does not exceed the MongoDB 16MB document size limit.

An excessively large document can occur on a ledger with a very large volume of small operations or a ledger with large operations (Continuity consensus caps operations sizes at 256K).

Here's some research that went into the current implementation: https://gist.github.com/mattcollier/b0e4d5fefa3a5640b329d9a73c02cc70