### PR TITLE
Do not pass objects to explain, booleans or strings only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-ledger-storage-mongodb ChangeLog
 
+## 4.0.1 - TBD
+
+## Changed
+- Fixed a bug where an object was being passed to MongoDB's `cursor.explain` method.
+
 ## 4.0.0 - 2020-12-01
 
 ### Changed

--- a/lib/LedgerOperationStorage.js
+++ b/lib/LedgerOperationStorage.js
@@ -73,7 +73,7 @@ class LedgerOperationStorage {
       query['meta.eventHash'] = eventHash;
     }
     if(explain) {
-      return this.collection.find(query).explain({executionStats: true});
+      return this.collection.find(query).explain('executionStats');
     }
     const count = await this.collection.countDocuments(query);
     return count === totalHashes;


### PR DESCRIPTION
My apologies about this one, looks like passing an `object` to `.explain(` now results in an error.

Fix for: https://github.com/digitalbazaar/bedrock-ledger-storage-mongodb/issues/58

I will review all uses of explain in our codebase and ensure we're not passing objects to them in the next day.