### PR TITLE
Remove `@context` AND parentHash dual index. Can't index two arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-ledger-storage-mongodb ChangeLog
 
+## 5.1.0 - 2021-xx-xx
+
+### Added
+- Added index support covered queries for aggregateStageEventProjection.
+
 ## 5.0.0 - 2021-04-29
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -259,6 +259,21 @@ async function _createCoreIndexes(
     fields: {'meta.eventHash': 1, 'meta.consensus': 1},
     options: {unique: true, background: false, name: 'event.eventHash.core.3'}
   }, {
+    // LedgerEventStorage.getMany query by `blockHeight`
+    collection: eventCollection,
+    fields: {
+      'meta.blockHeight': 1, 'meta.eventHash': 1, 'meta.eventOrder': 1,
+      'meta.blockOrder': 1, meta: 1, 'event.@context': 1,
+      'event.basisBlockHeight': 1, 'event.ledgerConfiguration': 1,
+      'event.parentHash': 1, 'event.proof': 1, 'event.treeHash': 1,
+      'event.type': 1,
+    },
+    options: {
+      name: 'event.blockHeight.core.1', unique: false, background: false,
+      // FIXME: Verify index is not used to find non-consensus events to
+      //        determine whether a `partialFilterExpression` is needed
+    }
+  }, {
     collection: eventCollection,
     fields: {'meta.consensus': 1, 'event.type': 1, 'meta.blockHeight': 1,
       'meta.blockOrder': 1},

--- a/lib/index.js
+++ b/lib/index.js
@@ -263,14 +263,14 @@ async function _createCoreIndexes(
     collection: eventCollection,
     fields: {
       'meta.blockHeight': 1, 'meta.eventHash': 1, 'meta.eventOrder': 1,
-      'meta.blockOrder': 1, meta: 1, 'event.basisBlockHeight': 1,
+      'meta.blockOrder': 1, 'event.basisBlockHeight': 1,
       'event.ledgerConfiguration': 1, 'event.parentHash': 1, 'event.proof': 1,
       'event.treeHash': 1, 'event.type': 1,
     },
     options: {
       name: 'event.blockHeight.core.1', unique: false, background: false,
-      // FIXME: Verify index is not used to find non-consensus events to
-      //        determine whether a `partialFilterExpression` is needed
+      // when consensus is true, a blockHeight and blockOrder is assigned
+      partialFilterExpression: {'meta.consensus': true}
     }
   }, {
     collection: eventCollection,

--- a/lib/index.js
+++ b/lib/index.js
@@ -263,10 +263,9 @@ async function _createCoreIndexes(
     collection: eventCollection,
     fields: {
       'meta.blockHeight': 1, 'meta.eventHash': 1, 'meta.eventOrder': 1,
-      'meta.blockOrder': 1, meta: 1, 'event.@context': 1,
-      'event.basisBlockHeight': 1, 'event.ledgerConfiguration': 1,
-      'event.parentHash': 1, 'event.proof': 1, 'event.treeHash': 1,
-      'event.type': 1,
+      'meta.blockOrder': 1, meta: 1, 'event.basisBlockHeight': 1,
+      'event.ledgerConfiguration': 1, 'event.parentHash': 1, 'event.proof': 1,
+      'event.treeHash': 1, 'event.type': 1,
     },
     options: {
       name: 'event.blockHeight.core.1', unique: false, background: false,


### PR DESCRIPTION
Now that `@context` is an array, and ?`parentHash` can be an array? (is that true)? You can't have indexes containing two arrays (or something like that)... MongoDB throws an error. 

This is the index that was causing the issue:

https://github.com/digitalbazaar/bedrock-ledger-storage-mongodb/pull/61/commits/ac84eb5af27086ebcff3fa7c5f5e75772ee188d5#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R265

Tests show no negative performance implications. However, we probably don't have appropriate tests for testing this index field. Why were we indexing @context in the first place? The index looks like a kitchen sink index... are we sure we need much of what's in it?